### PR TITLE
Log API Refactor

### DIFF
--- a/log/api.go
+++ b/log/api.go
@@ -57,11 +57,6 @@ func WithCtxRef(key string, ctxKey interface{}) Fields {
 	return Fields{}.WithCtxRef(key, ctxKey)
 }
 
-// WithFunc creates a field with a string key and a callback value.
-func WithFunc(key string, f func(context.Context) interface{}) Fields {
-	return Fields{}.WithFunc(key, f)
-}
-
 // WithLogger adds logger which will be used for the log operation.
 func WithLogger(logger Logger) Fields {
 	return Fields{}.WithLogger(logger)
@@ -138,11 +133,6 @@ func (f Fields) WithConfigs(configs ...Config) Fields {
 // WithCtxRef adds key and the context key to the fields.
 func (f Fields) WithCtxRef(key string, ctxKey interface{}) Fields {
 	return f.with(key, ctxRef{ctxKey})
-}
-
-// WithFunc adds key and the function to the fields.
-func (f Fields) WithFunc(key string, val func(context.Context) interface{}) Fields {
-	return f.with(key, val)
 }
 
 // WithLogger adds logger which will be used for the log operation.

--- a/log/api.go
+++ b/log/api.go
@@ -50,11 +50,11 @@ func WithConfigs(configs ...Config) Fields {
 	return Fields{}.WithConfigs(configs...)
 }
 
-// WithCtxRef creates a field with a key that refers to the provided context key,
+// WithContextRef creates a field with a key that refers to the provided context key,
 // fields will use key as the fields property and take the value that corresponds
 // to ctxKey.
-func WithCtxRef(key string, ctxKey interface{}) Fields {
-	return Fields{}.WithCtxRef(key, ctxKey)
+func WithContextRef(key string, ctxKey interface{}) Fields {
+	return Fields{}.WithContextRef(key, ctxKey)
 }
 
 // WithLogger adds logger which will be used for the log operation.
@@ -130,8 +130,8 @@ func (f Fields) WithConfigs(configs ...Config) Fields {
 	})
 }
 
-// WithCtxRef adds key and the context key to the fields.
-func (f Fields) WithCtxRef(key string, ctxKey interface{}) Fields {
+// WithContextRef adds key and the context key to the fields.
+func (f Fields) WithContextRef(key string, ctxKey interface{}) Fields {
 	return f.with(key, ctxRef{ctxKey})
 }
 

--- a/log/api.go
+++ b/log/api.go
@@ -50,11 +50,11 @@ func WithConfigs(configs ...Config) Fields {
 	return Fields{}.WithConfigs(configs...)
 }
 
-// WithContextRef creates a field with a key that refers to the provided context key,
+// WithContextKey creates a field with a key that refers to the provided context key,
 // fields will use key as the fields property and take the value that corresponds
 // to ctxKey.
-func WithContextRef(key string, ctxKey interface{}) Fields {
-	return Fields{}.WithContextRef(key, ctxKey)
+func WithContextKey(key string, ctxKey interface{}) Fields {
+	return Fields{}.WithContextKey(key, ctxKey)
 }
 
 // WithLogger adds logger which will be used for the log operation.
@@ -130,8 +130,8 @@ func (f Fields) WithConfigs(configs ...Config) Fields {
 	})
 }
 
-// WithContextRef adds key and the context key to the fields.
-func (f Fields) WithContextRef(key string, ctxKey interface{}) Fields {
+// WithContextKey adds key and the context key to the fields.
+func (f Fields) WithContextKey(key string, ctxKey interface{}) Fields {
 	return f.with(key, ctxRef{ctxKey})
 }
 

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -195,10 +195,10 @@ func TestWith(t *testing.T) {
 	)
 }
 
-func TestWithCtxRef(t *testing.T) {
+func TestWithContextRef(t *testing.T) {
 	t.Parallel()
 
-	f := WithCtxRef("key1", key1{}).WithCtxRef("key2", key2{}).WithCtxRef("key3", key3{})
+	f := WithContextRef("key1", key1{}).WithContextRef("key2", key2{}).WithContextRef("key3", key3{})
 
 	for i := f.m.Range(); i.Next(); {
 		assert.IsType(t, ctxRef{}, i.Value())

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -198,7 +198,7 @@ func TestWith(t *testing.T) {
 func TestWithContextRef(t *testing.T) {
 	t.Parallel()
 
-	f := WithContextRef("key1", key1{}).WithContextRef("key2", key2{}).WithContextRef("key3", key3{})
+	f := WithContextKey("key1", key1{}).WithContextKey("key2", key2{}).WithContextKey("key3", key3{})
 
 	for i := f.m.Range(); i.Next(); {
 		assert.IsType(t, ctxRef{}, i.Value())

--- a/log/examples.md
+++ b/log/examples.md
@@ -43,12 +43,12 @@ func fieldsDemo(ctx context.Context) {
 	// With adds a regular key value pair.
 	fields := log.With("hello", "world")
 
-	// WithCtxRef adds a key whose value will be taken from the context
+	// WithContextRef adds a key whose value will be taken from the context
 	// before logging. You have to define an alias to the key which will
 	// be used during logging as context key are usually a struct or iota
 	// which has no information about it when logged. If the key does not
 	// exist in the context, it will not be logged.
-	fields = fields.WithCtxRef("my alias", contextKey{})
+	fields = fields.WithContextRef("my alias", contextKey{})
 
 	// Fields operation can also be chained either by the With APIs or Chain API.
 	// An important thing to note is that fields operation always merge with the
@@ -59,7 +59,7 @@ func fieldsDemo(ctx context.Context) {
 	// In this example, the final fields will have ("test": "test four") instead of ("test": "test too").
 	fields = fields.
 		With("test", "test too").
-		WithCtxRef("test three", contextKey2{}).
+		WithContextRef("test three", contextKey2{}).
 		With("test", "test four")
 
 	// The final fields will have ("out of": "things to write")

--- a/log/examples.md
+++ b/log/examples.md
@@ -50,15 +50,6 @@ func fieldsDemo(ctx context.Context) {
 	// exist in the context, it will not be logged.
 	fields = fields.WithCtxRef("my alias", contextKey{})
 
-	// WithFunc adds a key and a function with a context argument which
-	// will be called before logging. If the result of the function is
-	// nil, it will not be logged.
-	ctx = context.WithValue(ctx, "bar", 42)
-	fields = fields.WithFunc("foo", func(ctx context.Context) interface{} {
-		return ctx.Value("bar")
-	})
-	ctx = context.WithValue(ctx, contextKey{}, "now exist in context")
-
 	// Fields operation can also be chained either by the With APIs or Chain API.
 	// An important thing to note is that fields operation always merge with the
 	// previous fields, but when key overlaps, the newest fields will always replace
@@ -69,9 +60,6 @@ func fieldsDemo(ctx context.Context) {
 	fields = fields.
 		With("test", "test too").
 		WithCtxRef("test three", contextKey2{}).
-		WithFunc("doesn't", func(context.Context) interface{} {
-			return "matter"
-		}).
 		With("test", "test four")
 
 	// The final fields will have ("out of": "things to write")

--- a/log/examples/example.go
+++ b/log/examples/example.go
@@ -32,17 +32,6 @@ func fieldsDemo(ctx context.Context) {
 	// exist in the context, it will not be logged.
 	fields = fields.WithCtxRef("my alias", contextKey{})
 
-	// WithFunc adds a key and a function with a context argument which
-	// will be called before logging. If the result of the function is
-	// nil, it will not be logged.
-	ctx = context.WithValue(ctx, "bar", 42)
-	fields = fields.WithFunc("foo", func(ctx context.Context) interface{} {
-		return ctx.Value("bar")
-	})
-	fmt.Printf("Current Fields after using the With API: %s\n", fields.String(ctx))
-	ctx = context.WithValue(ctx, contextKey{}, "now exist in context")
-	fmt.Printf("Current Fields after using the With API and adding my alias to context: %s\n", fields.String(ctx))
-
 	// Fields operation can also be chained either by the With APIs or Chain API.
 	// An important thing to note is that fields operation always merge with the
 	// previous fields, but when key overlaps, the newest fields will always replace
@@ -53,9 +42,6 @@ func fieldsDemo(ctx context.Context) {
 	fields = fields.
 		With("test", "test too").
 		WithCtxRef("test three", contextKey2{}).
-		WithFunc("doesn't", func(context.Context) interface{} {
-			return "matter"
-		}).
 		With("test", "test four")
 
 	// The final fields will have ("out of": "things to write")

--- a/log/examples/example.go
+++ b/log/examples/example.go
@@ -25,12 +25,12 @@ func fieldsDemo(ctx context.Context) {
 	// With adds a regular key value pair.
 	fields := log.With("hello", "world")
 
-	// WithContextRef adds a key whose value will be taken from the context
+	// WithContextKey adds a key whose value will be taken from the context
 	// before logging. You have to define an alias to the key which will
 	// be used during logging as context key are usually a struct or iota
 	// which has no information about it when logged. If the key does not
 	// exist in the context, it will not be logged.
-	fields = fields.WithContextRef("my alias", contextKey{})
+	fields = fields.WithContextKey("my alias", contextKey{})
 
 	// Fields operation can also be chained either by the With APIs or Chain API.
 	// An important thing to note is that fields operation always merge with the
@@ -41,7 +41,7 @@ func fieldsDemo(ctx context.Context) {
 	// In this example, the final fields will have ("test": "test four") instead of ("test": "test too").
 	fields = fields.
 		With("test", "test too").
-		WithContextRef("test three", contextKey2{}).
+		WithContextKey("test three", contextKey2{}).
 		With("test", "test four")
 
 	// The final fields will have ("out of": "things to write")

--- a/log/examples/example.go
+++ b/log/examples/example.go
@@ -25,12 +25,12 @@ func fieldsDemo(ctx context.Context) {
 	// With adds a regular key value pair.
 	fields := log.With("hello", "world")
 
-	// WithCtxRef adds a key whose value will be taken from the context
+	// WithContextRef adds a key whose value will be taken from the context
 	// before logging. You have to define an alias to the key which will
 	// be used during logging as context key are usually a struct or iota
 	// which has no information about it when logged. If the key does not
 	// exist in the context, it will not be logged.
-	fields = fields.WithCtxRef("my alias", contextKey{})
+	fields = fields.WithContextRef("my alias", contextKey{})
 
 	// Fields operation can also be chained either by the With APIs or Chain API.
 	// An important thing to note is that fields operation always merge with the
@@ -41,7 +41,7 @@ func fieldsDemo(ctx context.Context) {
 	// In this example, the final fields will have ("test": "test four") instead of ("test": "test too").
 	fields = fields.
 		With("test", "test too").
-		WithCtxRef("test three", contextKey2{}).
+		WithContextRef("test three", contextKey2{}).
 		With("test", "test four")
 
 	// The final fields will have ("out of": "things to write")


### PR DESCRIPTION
Fixes #19 

Removed `WithFunc` and changed `WithCtxRef` to `WithContextRef` for clearer name.