### PR TITLE
Added SetLevel configs to loggers

### DIFF
--- a/log/api_test.go
+++ b/log/api_test.go
@@ -93,9 +93,49 @@ func TestWithConfigsSameConfigType(t *testing.T) {
 	t.Parallel()
 
 	expectedConfig := frozen.Map{}.
-		With(standardFormat{}.TypeKey(), standardFormat{})
-	f := WithConfigs(NewJSONFormat(), NewStandardFormat())
+		With(standardFormat{}.TypeKey(), standardFormat{}).
+		With(infoLevel{}.TypeKey(), infoLevel{}).
+		With(stderrOut{}.TypeKey(), stderrOut{})
+
+	f := WithConfigs(
+		NewJSONFormat(),
+		NewStandardFormat(),
+		NewBufferOut(),
+		NewDebugLevel(),
+		NewInfoLevel(),
+		NewStderrOut(),
+	)
 	assert.True(t, expectedConfig.Equal(f.m))
+}
+
+func TestWithConfigLevel(t *testing.T) {
+	t.Parallel()
+
+	logger := newMockLogger()
+	setLogMockAssertion(logger, frozen.NewMap())
+	logger.On("SetLevel", errorLevel{}).Return(nil)
+	WithConfigs(NewInfoLevel(), NewDebugLevel(), NewErrorLevel()).WithLogger(logger).From(context.Background())
+	logger.AssertExpectations(t)
+}
+
+func TestWithConfigOut(t *testing.T) {
+	t.Parallel()
+
+	logger := newMockLogger()
+	setLogMockAssertion(logger, frozen.NewMap())
+	logger.On("SetOutput", stderrOut{}).Return(nil)
+	WithConfigs(NewStdOut(), NewBufferOut(), NewStderrOut()).WithLogger(logger).From(context.Background())
+	logger.AssertExpectations(t)
+}
+
+func TestWithConfigFormat(t *testing.T) {
+	t.Parallel()
+
+	logger := newMockLogger()
+	setLogMockAssertion(logger, frozen.NewMap())
+	logger.On("SetFormatter", jsonFormat{}).Return(nil)
+	WithConfigs(NewStandardFormat(), NewJSONFormat()).WithLogger(logger).From(context.Background())
+	logger.AssertExpectations(t)
 }
 
 func TestFrom(t *testing.T) {

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -109,7 +109,7 @@ func TestWithConfigLevel(t *testing.T) {
 
 	logger := newMockLogger()
 	setLogMockAssertion(logger, frozen.NewMap())
-	logger.On("SetVerbosity", true).Return(nil)
+	logger.On("SetVerbose", true).Return(nil)
 	WithConfigs(SetVerboseMode(false), SetVerboseMode(true)).WithLogger(logger).From(context.Background())
 	logger.AssertExpectations(t)
 }

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -94,15 +94,12 @@ func TestWithConfigsSameConfigType(t *testing.T) {
 
 	expectedConfig := frozen.Map{}.
 		With(standardFormat{}.TypeKey(), standardFormat{}).
-		With(verboseMode{}.TypeKey(), verboseMode{true}).
-		With(stderrOut{}.TypeKey(), stderrOut{})
+		With(verboseMode{}.TypeKey(), verboseMode{true})
 
 	f := WithConfigs(
 		NewJSONFormat(),
 		NewStandardFormat(),
-		NewBufferOut(),
 		SetVerboseMode(true),
-		NewStderrOut(),
 	)
 	assert.True(t, expectedConfig.Equal(f.m))
 }
@@ -114,16 +111,6 @@ func TestWithConfigLevel(t *testing.T) {
 	setLogMockAssertion(logger, frozen.NewMap())
 	logger.On("SetVerbosity", true).Return(nil)
 	WithConfigs(SetVerboseMode(false), SetVerboseMode(true)).WithLogger(logger).From(context.Background())
-	logger.AssertExpectations(t)
-}
-
-func TestWithConfigOut(t *testing.T) {
-	t.Parallel()
-
-	logger := newMockLogger()
-	setLogMockAssertion(logger, frozen.NewMap())
-	logger.On("SetOutput", stderrOut{}).Return(nil)
-	WithConfigs(NewStdOut(), NewBufferOut(), NewStderrOut()).WithLogger(logger).From(context.Background())
 	logger.AssertExpectations(t)
 }
 

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -94,15 +94,14 @@ func TestWithConfigsSameConfigType(t *testing.T) {
 
 	expectedConfig := frozen.Map{}.
 		With(standardFormat{}.TypeKey(), standardFormat{}).
-		With(infoLevel{}.TypeKey(), infoLevel{}).
+		With(verboseMode{}.TypeKey(), verboseMode{true}).
 		With(stderrOut{}.TypeKey(), stderrOut{})
 
 	f := WithConfigs(
 		NewJSONFormat(),
 		NewStandardFormat(),
 		NewBufferOut(),
-		NewDebugLevel(),
-		NewInfoLevel(),
+		SetVerboseMode(true),
 		NewStderrOut(),
 	)
 	assert.True(t, expectedConfig.Equal(f.m))
@@ -113,8 +112,8 @@ func TestWithConfigLevel(t *testing.T) {
 
 	logger := newMockLogger()
 	setLogMockAssertion(logger, frozen.NewMap())
-	logger.On("SetLevel", errorLevel{}).Return(nil)
-	WithConfigs(NewInfoLevel(), NewDebugLevel(), NewErrorLevel()).WithLogger(logger).From(context.Background())
+	logger.On("SetVerbosity", true).Return(nil)
+	WithConfigs(SetVerboseMode(false), SetVerboseMode(true)).WithLogger(logger).From(context.Background())
 	logger.AssertExpectations(t)
 }
 

--- a/log/config.go
+++ b/log/config.go
@@ -2,7 +2,11 @@ package log
 
 type typeKey int
 
-const Formatter typeKey = iota
+const (
+	Formatter typeKey = iota
+	LevelSetter
+	OutSetter
+)
 
 type Config interface {
 	TypeKey() interface{}
@@ -11,6 +15,14 @@ type Config interface {
 
 type standardFormat struct{}
 type jsonFormat struct{}
+
+type errorLevel struct{}
+type debugLevel struct{}
+type infoLevel struct{}
+
+type stderrOut struct{}
+type stdOut struct{}
+type bufferOut struct{}
 
 func NewStandardFormat() Config             { return standardFormat{} }
 func (standardFormat) TypeKey() interface{} { return Formatter }
@@ -24,6 +36,50 @@ func (jf jsonFormat) Apply(logger Logger) error {
 	return applyFormatter(jf, logger)
 }
 
+func NewErrorLevel() Config             { return errorLevel{} }
+func (errorLevel) TypeKey() interface{} { return LevelSetter }
+func (el errorLevel) Apply(logger Logger) error {
+	return applyLevel(el, logger)
+}
+
+func NewDebugLevel() Config             { return debugLevel{} }
+func (debugLevel) TypeKey() interface{} { return LevelSetter }
+func (dl debugLevel) Apply(logger Logger) error {
+	return applyLevel(dl, logger)
+}
+
+func NewInfoLevel() Config             { return infoLevel{} }
+func (infoLevel) TypeKey() interface{} { return LevelSetter }
+func (il infoLevel) Apply(logger Logger) error {
+	return applyLevel(il, logger)
+}
+
+func NewStderrOut() Config             { return stderrOut{} }
+func (stderrOut) TypeKey() interface{} { return OutSetter }
+func (se stderrOut) Apply(logger Logger) error {
+	return applyOutput(se, logger)
+}
+
+func NewStdOut() Config             { return stdOut{} }
+func (stdOut) TypeKey() interface{} { return OutSetter }
+func (s stdOut) Apply(logger Logger) error {
+	return applyOutput(s, logger)
+}
+
+func NewBufferOut() Config             { return bufferOut{} }
+func (bufferOut) TypeKey() interface{} { return OutSetter }
+func (b bufferOut) Apply(logger Logger) error {
+	return applyOutput(b, logger)
+}
+
 func applyFormatter(formatter Config, logger Logger) error {
 	return logger.(formattable).SetFormatter(formatter)
+}
+
+func applyLevel(level Config, logger Logger) error {
+	return logger.(settableLevel).SetLevel(level)
+}
+
+func applyOutput(out Config, logger Logger) error {
+	return logger.(settableOutput).SetOutput(out)
 }

--- a/log/config.go
+++ b/log/config.go
@@ -4,7 +4,7 @@ type typeKey int
 
 const (
 	Formatter typeKey = iota
-	LevelSetter
+	verbosity
 	OutSetter
 )
 
@@ -16,9 +16,7 @@ type Config interface {
 type standardFormat struct{}
 type jsonFormat struct{}
 
-type errorLevel struct{}
-type debugLevel struct{}
-type infoLevel struct{}
+type verboseMode struct{ on bool }
 
 type stderrOut struct{}
 type stdOut struct{}
@@ -36,22 +34,10 @@ func (jf jsonFormat) Apply(logger Logger) error {
 	return applyFormatter(jf, logger)
 }
 
-func NewErrorLevel() Config             { return errorLevel{} }
-func (errorLevel) TypeKey() interface{} { return LevelSetter }
-func (el errorLevel) Apply(logger Logger) error {
-	return applyLevel(el, logger)
-}
-
-func NewDebugLevel() Config             { return debugLevel{} }
-func (debugLevel) TypeKey() interface{} { return LevelSetter }
-func (dl debugLevel) Apply(logger Logger) error {
-	return applyLevel(dl, logger)
-}
-
-func NewInfoLevel() Config             { return infoLevel{} }
-func (infoLevel) TypeKey() interface{} { return LevelSetter }
-func (il infoLevel) Apply(logger Logger) error {
-	return applyLevel(il, logger)
+func SetVerboseMode(on bool) Config      { return verboseMode{on} }
+func (verboseMode) TypeKey() interface{} { return verbosity }
+func (v verboseMode) Apply(logger Logger) error {
+	return logger.(settableVerbosity).SetVerbosity(v.on)
 }
 
 func NewStderrOut() Config             { return stderrOut{} }
@@ -74,10 +60,6 @@ func (b bufferOut) Apply(logger Logger) error {
 
 func applyFormatter(formatter Config, logger Logger) error {
 	return logger.(formattable).SetFormatter(formatter)
-}
-
-func applyLevel(level Config, logger Logger) error {
-	return logger.(settableLevel).SetLevel(level)
 }
 
 func applyOutput(out Config, logger Logger) error {

--- a/log/config.go
+++ b/log/config.go
@@ -30,10 +30,14 @@ func (jf jsonFormat) Apply(logger Logger) error {
 	return applyFormatter(jf, logger)
 }
 
-func SetVerboseMode(on bool) Config      { return verboseMode{on} }
+func SetVerboseMode(on bool) Config {
+	return verboseMode{on}
+}
+
 func (verboseMode) TypeKey() interface{} { return verbosity }
+
 func (v verboseMode) Apply(logger Logger) error {
-	return logger.(settableVerbosity).SetVerbosity(v.on)
+	return logger.(settableVerbosity).SetVerbose(v.on)
 }
 
 func applyFormatter(formatter Config, logger Logger) error {

--- a/log/config.go
+++ b/log/config.go
@@ -18,10 +18,6 @@ type jsonFormat struct{}
 
 type verboseMode struct{ on bool }
 
-type stderrOut struct{}
-type stdOut struct{}
-type bufferOut struct{}
-
 func NewStandardFormat() Config             { return standardFormat{} }
 func (standardFormat) TypeKey() interface{} { return Formatter }
 func (sf standardFormat) Apply(logger Logger) error {
@@ -40,28 +36,6 @@ func (v verboseMode) Apply(logger Logger) error {
 	return logger.(settableVerbosity).SetVerbosity(v.on)
 }
 
-func NewStderrOut() Config             { return stderrOut{} }
-func (stderrOut) TypeKey() interface{} { return OutSetter }
-func (se stderrOut) Apply(logger Logger) error {
-	return applyOutput(se, logger)
-}
-
-func NewStdOut() Config             { return stdOut{} }
-func (stdOut) TypeKey() interface{} { return OutSetter }
-func (s stdOut) Apply(logger Logger) error {
-	return applyOutput(s, logger)
-}
-
-func NewBufferOut() Config             { return bufferOut{} }
-func (bufferOut) TypeKey() interface{} { return OutSetter }
-func (b bufferOut) Apply(logger Logger) error {
-	return applyOutput(b, logger)
-}
-
 func applyFormatter(formatter Config, logger Logger) error {
 	return logger.(formattable).SetFormatter(formatter)
-}
-
-func applyOutput(out Config, logger Logger) error {
-	return logger.(settableOutput).SetOutput(out)
 }

--- a/log/config.go
+++ b/log/config.go
@@ -1,11 +1,14 @@
 package log
 
 type typeKey int
+type internalTypeKey int
 
 const (
 	Formatter typeKey = iota
-	verbosity
-	OutSetter
+)
+
+const (
+	verbosity internalTypeKey = iota
 )
 
 type Config interface {

--- a/log/examples.md
+++ b/log/examples.md
@@ -177,15 +177,15 @@ func configLogDemo(ctx context.Context) {
 	// of the same type is added. For example, if before you added StandardFormatter, calling WithConfig
 	// with JSONFormatter will replace StandardFormatter. Just like Fields, it will also be stored
 	// in the context.
-	ctx = log.WithConfigs(log.NewJSONFormat()).Onto(ctx)
-    
-    // You can also have a log-specific configs by not saving it to the context.
-    log.WithConfigs(log.NewStandardFormat(), log.NewStandardFormat()).
-        WithLogger(log.NewStandardLogger()).
-        With("yeet", map[string]interface{}{"foo": "bar", "doesn't": "matter"}).
-        From(ctx).
-        Info("json formatted log")
-}
+	ctx = log.WithConfigs(log.NewJSONFormat(), log.NewStderrOut(), log.NewDebugLevel()).Onto(ctx)
+
+	// You can also have a log-specific configs by not saving it to the context.
+	log.WithConfigs(log.NewStandardFormat(), log.NewBufferOut(), log.NewInfoLevel()).
+		WithLogger(log.NewStandardLogger()).
+		With("key", map[string]interface{}{"foo": "bar", "doesn't": "matter"}
+		}).
+		From(ctx).
+		Info("json formatted log")
 ```
 
 Code snippets can be run in the [example file](examples/example.go)

--- a/log/examples.md
+++ b/log/examples.md
@@ -177,15 +177,15 @@ func configLogDemo(ctx context.Context) {
 	// of the same type is added. For example, if before you added StandardFormatter, calling WithConfig
 	// with JSONFormatter will replace StandardFormatter. Just like Fields, it will also be stored
 	// in the context.
-	ctx = log.WithConfigs(log.NewJSONFormat(), log.NewStderrOut(), log.NewDebugLevel()).Onto(ctx)
+	ctx = log.WithConfigs(log.NewJSONFormat(), log.NewStderrOut(), log.SetVerboseMode(true)).Onto(ctx)
 
 	// You can also have a log-specific configs by not saving it to the context.
-	log.WithConfigs(log.NewStandardFormat(), log.NewBufferOut(), log.NewInfoLevel()).
+	log.WithConfigs(log.NewStandardFormat(), log.NewBufferOut(), log.SetVerboseMode(false)).
 		WithLogger(log.NewStandardLogger()).
-		With("key", map[string]interface{}{"foo": "bar", "doesn't": "matter"}
-		}).
+		With("key", map[string]interface{}{"foo": "bar", "doesn't": "matter"}).
 		From(ctx).
 		Info("json formatted log")
+}
 ```
 
 Code snippets can be run in the [example file](examples/example.go)

--- a/log/examples/example.go
+++ b/log/examples/example.go
@@ -139,10 +139,10 @@ func configLogDemo(ctx context.Context) {
 	// of the same type is added. For example, if before you added StandardFormatter, calling WithConfig
 	// with JSONFormatter will replace StandardFormatter. Just like Fields, it will also be stored
 	// in the context.
-	ctx = log.WithConfigs(log.NewJSONFormat(), log.NewStderrOut(), log.NewDebugLevel()).Onto(ctx)
+	ctx = log.WithConfigs(log.NewJSONFormat(), log.NewStderrOut(), log.SetVerboseMode(true)).Onto(ctx)
 
 	// You can also have a log-specific configs by not saving it to the context.
-	log.WithConfigs(log.NewStandardFormat(), log.NewBufferOut(), log.NewInfoLevel()).
+	log.WithConfigs(log.NewStandardFormat(), log.NewBufferOut(), log.SetVerboseMode(false)).
 		WithLogger(log.NewStandardLogger()).
 		With("key", map[string]interface{}{"foo": "bar", "doesn't": "matter"}).
 		From(ctx).

--- a/log/examples/example.go
+++ b/log/examples/example.go
@@ -139,12 +139,12 @@ func configLogDemo(ctx context.Context) {
 	// of the same type is added. For example, if before you added StandardFormatter, calling WithConfig
 	// with JSONFormatter will replace StandardFormatter. Just like Fields, it will also be stored
 	// in the context.
-	ctx = log.WithConfigs(log.NewJSONFormat()).Onto(ctx)
+	ctx = log.WithConfigs(log.NewJSONFormat(), log.NewStderrOut(), log.NewDebugLevel()).Onto(ctx)
 
 	// You can also have a log-specific configs by not saving it to the context.
-	log.WithConfigs(log.NewStandardFormat(), log.NewStandardFormat()).
+	log.WithConfigs(log.NewStandardFormat(), log.NewBufferOut(), log.NewInfoLevel()).
 		WithLogger(log.NewStandardLogger()).
-		With("yeet", map[string]interface{}{"foo": "bar", "doesn't": "matter"}).
+		With("key", map[string]interface{}{"foo": "bar", "doesn't": "matter"}).
 		From(ctx).
 		Info("json formatted log")
 }

--- a/log/examples/example.go
+++ b/log/examples/example.go
@@ -139,10 +139,10 @@ func configLogDemo(ctx context.Context) {
 	// of the same type is added. For example, if before you added StandardFormatter, calling WithConfig
 	// with JSONFormatter will replace StandardFormatter. Just like Fields, it will also be stored
 	// in the context.
-	ctx = log.WithConfigs(log.NewJSONFormat(), log.NewStderrOut(), log.SetVerboseMode(true)).Onto(ctx)
+	ctx = log.WithConfigs(log.NewJSONFormat(), log.SetVerboseMode(true)).Onto(ctx)
 
 	// You can also have a log-specific configs by not saving it to the context.
-	log.WithConfigs(log.NewStandardFormat(), log.NewBufferOut(), log.SetVerboseMode(false)).
+	log.WithConfigs(log.NewStandardFormat(), log.SetVerboseMode(false)).
 		WithLogger(log.NewStandardLogger()).
 		With("key", map[string]interface{}{"foo": "bar", "doesn't": "matter"}).
 		From(ctx).

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -30,6 +30,6 @@ type formattable interface {
 }
 
 type settableVerbosity interface {
-	// SetVerbosity sets the verbosity of the logger.
-	SetVerbosity(on bool) error
+	// SetVerbose sets the verbosity of the logger.
+	SetVerbose(on bool) error
 }

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -2,29 +2,39 @@ package log
 
 import "github.com/arr-ai/frozen"
 
-// Logger is the underlying logger that is to be added to a context
+// Logger is the underlying logger that is to be added to a context.
 type Logger interface {
-	// Debug logs the message at the Debug level
+	// Debug logs the message at the Debug level.
 	Debug(args ...interface{})
-	// Debugf logs the message at the Debug level
+	// Debugf logs the message at the Debug level.
 	Debugf(format string, args ...interface{})
-	// Info logs the message at the Info level
+	// Info logs the message at the Info level.
 	Info(args ...interface{})
-	// Infof logs the message at the Info level
+	// Infof logs the message at the Info level.
 	Infof(format string, args ...interface{})
 }
 
 type copyable interface {
-	// Copy returns a logger whose data is copied from the caller
+	// Copy returns a logger whose data is copied from the caller.
 	Copy() Logger
 }
 
 type fieldSetter interface {
-	// PutFields returns the Logger with the new fields added
+	// PutFields returns the Logger with the new fields added.
 	PutFields(fields frozen.Map) Logger
 }
 
 type formattable interface {
-	// SetFormatter sets the formatter for the logger
+	// SetFormatter sets the formatter for the logger.￿
 	SetFormatter(formatter Config) error
+}
+
+type settableLevel interface {
+	// SetLevel sets the logger level.
+	SetLevel(level Config) error
+}
+
+type settableOutput interface {
+	// SetOutput sets where the logger outputs its logs.
+	SetOutput(output Config) error
 }

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -33,8 +33,3 @@ type settableVerbosity interface {
 	// SetVerbosity sets the verbosity of the logger.
 	SetVerbosity(on bool) error
 }
-
-type settableOutput interface {
-	// SetOutput sets where the logger outputs its logs.
-	SetOutput(output Config) error
-}

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -29,9 +29,9 @@ type formattable interface {
 	SetFormatter(formatter Config) error
 }
 
-type settableLevel interface {
-	// SetLevel sets the logger level.
-	SetLevel(level Config) error
+type settableVerbosity interface {
+	// SetVerbosity sets the verbosity of the logger.
+	SetVerbosity(on bool) error
 }
 
 type settableOutput interface {

--- a/log/mockLogger.go
+++ b/log/mockLogger.go
@@ -41,3 +41,11 @@ func (m *mockLogger) Copy() Logger {
 func (m *mockLogger) SetFormatter(formatter Config) error {
 	return m.Called(formatter).Error(0)
 }
+
+func (m *mockLogger) SetLevel(level Config) error {
+	return m.Called(level).Error(0)
+}
+
+func (m *mockLogger) SetOutput(out Config) error {
+	return m.Called(out).Error(0)
+}

--- a/log/mockLogger.go
+++ b/log/mockLogger.go
@@ -45,7 +45,3 @@ func (m *mockLogger) SetFormatter(formatter Config) error {
 func (m *mockLogger) SetVerbosity(on bool) error {
 	return m.Called(on).Error(0)
 }
-
-func (m *mockLogger) SetOutput(out Config) error {
-	return m.Called(out).Error(0)
-}

--- a/log/mockLogger.go
+++ b/log/mockLogger.go
@@ -42,8 +42,8 @@ func (m *mockLogger) SetFormatter(formatter Config) error {
 	return m.Called(formatter).Error(0)
 }
 
-func (m *mockLogger) SetLevel(level Config) error {
-	return m.Called(level).Error(0)
+func (m *mockLogger) SetVerbosity(on bool) error {
+	return m.Called(on).Error(0)
 }
 
 func (m *mockLogger) SetOutput(out Config) error {

--- a/log/mockLogger.go
+++ b/log/mockLogger.go
@@ -42,6 +42,6 @@ func (m *mockLogger) SetFormatter(formatter Config) error {
 	return m.Called(formatter).Error(0)
 }
 
-func (m *mockLogger) SetVerbosity(on bool) error {
+func (m *mockLogger) SetVerbose(on bool) error {
 	return m.Called(on).Error(0)
 }

--- a/log/nullLogger.go
+++ b/log/nullLogger.go
@@ -50,10 +50,6 @@ func (n *nullLogger) SetVerbosity(on bool) error {
 	return n.internal.SetVerbosity(on)
 }
 
-func (n *nullLogger) SetOutput(out Config) error {
-	return n.internal.SetOutput(out)
-}
-
 func setUpLogger() *standardLogger {
 	logger := NewStandardLogger().(*standardLogger)
 	logger.internal.SetOutput(&bytes.Buffer{})

--- a/log/nullLogger.go
+++ b/log/nullLogger.go
@@ -46,8 +46,8 @@ func (n *nullLogger) SetFormatter(formatter Config) error {
 	return n.internal.SetFormatter(formatter)
 }
 
-func (n *nullLogger) SetLevel(level Config) error {
-	return n.internal.SetLevel(level)
+func (n *nullLogger) SetVerbosity(on bool) error {
+	return n.internal.SetVerbosity(on)
 }
 
 func (n *nullLogger) SetOutput(out Config) error {

--- a/log/nullLogger.go
+++ b/log/nullLogger.go
@@ -46,6 +46,14 @@ func (n *nullLogger) SetFormatter(formatter Config) error {
 	return n.internal.SetFormatter(formatter)
 }
 
+func (n *nullLogger) SetLevel(level Config) error {
+	return n.internal.SetLevel(level)
+}
+
+func (n *nullLogger) SetOutput(out Config) error {
+	return n.internal.SetOutput(out)
+}
+
 func setUpLogger() *standardLogger {
 	logger := NewStandardLogger().(*standardLogger)
 	logger.internal.SetOutput(&bytes.Buffer{})

--- a/log/nullLogger.go
+++ b/log/nullLogger.go
@@ -46,8 +46,8 @@ func (n *nullLogger) SetFormatter(formatter Config) error {
 	return n.internal.SetFormatter(formatter)
 }
 
-func (n *nullLogger) SetVerbosity(on bool) error {
-	return n.internal.SetVerbosity(on)
+func (n *nullLogger) SetVerbose(on bool) error {
+	return n.internal.SetVerbose(on)
 }
 
 func setUpLogger() *standardLogger {

--- a/log/standardLogger.go
+++ b/log/standardLogger.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -74,8 +73,6 @@ func (jf jsonFormat) Format(entry *logrus.Entry) ([]byte, error) {
 func NewStandardLogger() Logger {
 	logger := logrus.New()
 	logger.SetFormatter(&standardFormat{})
-	// explicitly set it to os.Stderr
-	logger.SetOutput(os.Stderr)
 
 	return &standardLogger{internal: logger}
 }

--- a/log/standardLogger.go
+++ b/log/standardLogger.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,10 +27,6 @@ type standardLogger struct {
 	internal *logrus.Logger
 	fields   frozen.Map
 }
-
-func (stderrOut) getIoOut() io.Writer { return os.Stderr }
-func (stdOut) getIoOut() io.Writer    { return os.Stdout }
-func (bufferOut) getIoOut() io.Writer { return &bytes.Buffer{} }
 
 func (sf standardFormat) Format(entry *logrus.Entry) ([]byte, error) {
 	message := strings.Builder{}

--- a/log/standardLogger.go
+++ b/log/standardLogger.go
@@ -29,10 +29,6 @@ type standardLogger struct {
 	fields   frozen.Map
 }
 
-func (errorLevel) getLogrusLevel() logrus.Level { return logrus.ErrorLevel }
-func (debugLevel) getLogrusLevel() logrus.Level { return logrus.DebugLevel }
-func (infoLevel) getLogrusLevel() logrus.Level  { return logrus.InfoLevel }
-
 func (stderrOut) getIoOut() io.Writer { return os.Stderr }
 func (stdOut) getIoOut() io.Writer    { return os.Stdout }
 func (bufferOut) getIoOut() io.Writer { return &bytes.Buffer{} }
@@ -119,12 +115,12 @@ func (sl *standardLogger) SetFormatter(formatter Config) error {
 	return nil
 }
 
-func (sl *standardLogger) SetLevel(level Config) error {
-	logrusLevel, isLogrusLevelConfig := level.(logrusLevelConfig)
-	if !isLogrusLevelConfig {
-		return errors.New("level is logrus type")
+func (sl *standardLogger) SetVerbosity(on bool) error {
+	if on {
+		sl.internal.SetLevel(logrus.DebugLevel)
+	} else {
+		sl.internal.SetLevel(logrus.InfoLevel)
 	}
-	sl.internal.SetLevel(logrusLevel.getLogrusLevel())
 	return nil
 }
 

--- a/log/standardLogger.go
+++ b/log/standardLogger.go
@@ -110,21 +110,12 @@ func (sl *standardLogger) SetFormatter(formatter Config) error {
 	return nil
 }
 
-func (sl *standardLogger) SetVerbosity(on bool) error {
+func (sl *standardLogger) SetVerbose(on bool) error {
 	if on {
 		sl.internal.SetLevel(logrus.DebugLevel)
 	} else {
 		sl.internal.SetLevel(logrus.InfoLevel)
 	}
-	return nil
-}
-
-func (sl *standardLogger) SetOutput(out Config) error {
-	ioOut, isIoOut := out.(ioOutConfig)
-	if !isIoOut {
-		return errors.New("out does not implement io.Writer")
-	}
-	sl.internal.SetOutput(ioOut.getIoOut())
 	return nil
 }
 

--- a/log/standardLogger_test.go
+++ b/log/standardLogger_test.go
@@ -37,7 +37,7 @@ func TestCopyStandardLogger(t *testing.T) {
 
 func TestDebug(t *testing.T) {
 	testStandardLogOutput(t, logrus.DebugLevel, frozen.NewMap(), func() {
-		NewStandardLogger().Debug(testMessage)
+		getNewStandardLogger().Debug(testMessage)
 	})
 
 	testJSONLogOutput(t, logrus.DebugLevel, frozen.NewMap(), func() {
@@ -59,7 +59,7 @@ func TestDebug(t *testing.T) {
 
 func TestDebugf(t *testing.T) {
 	testStandardLogOutput(t, logrus.DebugLevel, frozen.NewMap(), func() {
-		NewStandardLogger().Debugf(simpleFormat, testMessage)
+		getNewStandardLogger().Debugf(simpleFormat, testMessage)
 	})
 
 	testJSONLogOutput(t, logrus.DebugLevel, frozen.NewMap(), func() {
@@ -81,7 +81,7 @@ func TestDebugf(t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	testStandardLogOutput(t, logrus.InfoLevel, frozen.NewMap(), func() {
-		NewStandardLogger().Info(testMessage)
+		getNewStandardLogger().Info(testMessage)
 	})
 
 	testJSONLogOutput(t, logrus.InfoLevel, frozen.NewMap(), func() {
@@ -103,7 +103,7 @@ func TestInfo(t *testing.T) {
 
 func TestInfof(t *testing.T) {
 	testStandardLogOutput(t, logrus.InfoLevel, frozen.NewMap(), func() {
-		NewStandardLogger().Infof(simpleFormat, testMessage)
+		getNewStandardLogger().Infof(simpleFormat, testMessage)
 	})
 
 	testJSONLogOutput(t, logrus.InfoLevel, frozen.NewMap(), func() {
@@ -196,10 +196,13 @@ func TestPutFields(t *testing.T) {
 }
 
 func getNewStandardLogger() *standardLogger {
-	return NewStandardLogger().(*standardLogger)
+	l := NewStandardLogger().(*standardLogger)
+	l.internal.SetLevel(logrus.DebugLevel)
+	return l
 }
 
 func getStandardLoggerWithFields() *standardLogger {
-	logger := getNewStandardLogger().PutFields(testField)
-	return logger.(*standardLogger)
+	logger := getNewStandardLogger().PutFields(testField).(*standardLogger)
+	logger.internal.SetLevel(logrus.DebugLevel)
+	return logger
 }


### PR DESCRIPTION
Added new configuration for verbosity

use the `log.SetVerboseMode(on bool)` to set whether the logger should be verbose or not.