### PR TITLE
logger doesn't panic if there's no logger in ctx

### DIFF
--- a/log/util.go
+++ b/log/util.go
@@ -25,7 +25,7 @@ func (f *fieldsCollector) PutFields(fields frozen.Map) Logger {
 func (f Fields) getCopiedLogger() Logger {
 	logger, exists := f.m.Get(loggerKey{})
 	if !exists {
-		panic("Logger has not been added")
+		return NewStandardLogger()
 	}
 	return logger.(copyable).Copy()
 }


### PR DESCRIPTION
Logger doesn't panic if it does not exist in context.