### PR TITLE
changed position of level to be after timestamp

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -202,13 +202,13 @@ Fields will be logged as an object of the attribute `fields`. One thing to remem
 The standard formatter will log in the following format without the parentheses:
 
 ```text
-(time in RFC3339Nano Format) (Fields) (Level) (Message)
+(time in RFC3339Nano Format) (Level) (Fields) (Message)
 ```
 
 For example:
 
 ```log
-2020-02-05T09:05:11.041651+11:00 this=one have=fields INFO log with fields
+2020-02-05T09:05:11.041651+11:00 INFO this=one have=fields log with fields
 ```
 
 In the current implementation, the fields are logged in a random order.

--- a/log/examples.md
+++ b/log/examples.md
@@ -122,7 +122,7 @@ func loggingDemo(ctx context.Context) {
 	// by the logger. There are two levels of logging, Debug and Info. Each will also have
 	// the format counterpart, Debugf and Infof.
 	// Logging will log in the following format:
-	// (time in RFC3339Nano Format) (Fields) (Level) (Message)
+	// (time in RFC3339Nano Format) (Level) (Fields) (Message)
 	// Fields themselves are logged as a space separated list of key=value
 	log.From(ctx).Debug("This does not have any fields")
 

--- a/log/examples/example.go
+++ b/log/examples/example.go
@@ -103,7 +103,7 @@ func loggingDemo(ctx context.Context) {
 	// by the logger. There are two levels of logging, Debug and Info. Each will also have
 	// the format counterpart, Debugf and Infof.
 	// Logging will log in the following format:
-	// (time in RFC3339Nano Format) (Fields) (Level) (Message)
+	// (time in RFC3339Nano Format) (Level) (Fields) (Message)
 	// Fields themselves are logged as a space separated list of key=value.
 	log.From(ctx).Debug("This does not have any fields")
 

--- a/log/standardLogger_test.go
+++ b/log/standardLogger_test.go
@@ -172,11 +172,11 @@ func TestInfof(t *testing.T) {
 }
 
 func testStandardLogOutput(t *testing.T, level logrus.Level, fields frozen.Map, logFunc func()) {
-	expectedOutput := strings.Join([]string{strings.ToUpper(level.String()), testMessage}, " ")
 	actualOutput := redirectOutput(t, logFunc)
 
 	// uses Contains to avoid checking timestamps
-	assert.Contains(t, actualOutput, expectedOutput)
+	assert.Contains(t, actualOutput, strings.ToUpper(level.String()))
+	assert.Contains(t, actualOutput, testMessage)
 	for i := fields.Range(); i.Next(); {
 		assert.Contains(t, actualOutput, fmt.Sprintf("%s=%v", i.Key(), i.Value()))
 	}


### PR DESCRIPTION
Standard format is now changed to
```
(timestamp) (level) (fields) (message)
```