### PR TITLE
Make formatter application public

### DIFF
--- a/log/config.go
+++ b/log/config.go
@@ -28,13 +28,13 @@ type outputConfig struct{ writer io.Writer }
 func NewStandardFormat() Config             { return standardFormat{} }
 func (standardFormat) TypeKey() interface{} { return Formatter }
 func (sf standardFormat) Apply(logger Logger) error {
-	return applyFormatter(sf, logger)
+	return ApplyFormatter(sf, logger)
 }
 
 func NewJSONFormat() Config             { return jsonFormat{} }
 func (jsonFormat) TypeKey() interface{} { return Formatter }
 func (jf jsonFormat) Apply(logger Logger) error {
-	return applyFormatter(jf, logger)
+	return ApplyFormatter(jf, logger)
 }
 
 func SetVerboseMode(on bool) Config {
@@ -57,6 +57,6 @@ func (o outputConfig) Apply(logger Logger) error {
 	return logger.(settableOutput).SetOutput(o.writer)
 }
 
-func applyFormatter(formatter Config, logger Logger) error {
+func ApplyFormatter(formatter Config, logger Logger) error {
 	return logger.(formattable).SetFormatter(formatter)
 }


### PR DESCRIPTION
To enable custom logging formatters to be set they must have
the ability to be applied through a config. This change enables
custom formatters to be applied.