### PR TITLE
exported configurable interface to allow custom config for builtin loggers

### DIFF
--- a/log/config.go
+++ b/log/config.go
@@ -44,7 +44,7 @@ func SetVerboseMode(on bool) Config {
 func (verboseMode) TypeKey() interface{} { return verbosity }
 
 func (v verboseMode) Apply(logger Logger) error {
-	return logger.(settableVerbosity).SetVerbose(v.on)
+	return logger.(SettableVerbosity).SetVerbose(v.on)
 }
 
 func SetOutput(w io.Writer) Config {
@@ -54,9 +54,9 @@ func SetOutput(w io.Writer) Config {
 func (outputConfig) TypeKey() interface{} { return output }
 
 func (o outputConfig) Apply(logger Logger) error {
-	return logger.(settableOutput).SetOutput(o.writer)
+	return logger.(SettableOutput).SetOutput(o.writer)
 }
 
 func applyFormatter(formatter Config, logger Logger) error {
-	return logger.(formattable).SetFormatter(formatter)
+	return logger.(Formattable).SetFormatter(formatter)
 }

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -32,17 +32,17 @@ type fieldSetter interface {
 	PutFields(fields frozen.Map) Logger
 }
 
-type formattable interface {
+type Formattable interface {
 	// SetFormatter sets the formatter for the logger.￿
 	SetFormatter(formatter Config) error
 }
 
-type settableVerbosity interface {
+type SettableVerbosity interface {
 	// SetVerbose sets the verbosity of the logger.
 	SetVerbose(on bool) error
 }
 
-type settableOutput interface {
+type SettableOutput interface {
 	// SetOutput sets where the logger outputs to.
 	SetOutput(w io.Writer) error
 }


### PR DESCRIPTION
the configurable interface which the custom config  needs to access have to be exported so that user can create custom configuration for the builtin logger.