### PR TITLE
Entry and Formatter types

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -224,4 +224,4 @@ type Config interface {
 }
 ```
 
-`TypeKey()` returns the type of the configuration and `Apply()` will apply the configuration to the logger. For formatters, use the `Formatter` type key provided by the library to ensure that it is recognized as a formatter. Formatters meant for `StandardLogger` need to implement [logrus' formatter](https://github.com/sirupsen/logrus#Formatters).
+`TypeKey()` returns the type of the configuration and `Apply()` will apply the configuration to the logger. For formatters, use the `FormatterType` type key provided by the library to ensure that it is recognized as a formatter.

--- a/log/config.go
+++ b/log/config.go
@@ -6,7 +6,7 @@ type typeKey int
 type internalTypeKey int
 
 const (
-	Formatter typeKey = iota
+	FormatterType typeKey = iota
 )
 
 const (
@@ -26,13 +26,13 @@ type verboseMode struct{ on bool }
 type outputConfig struct{ writer io.Writer }
 
 func NewStandardFormat() Config             { return standardFormat{} }
-func (standardFormat) TypeKey() interface{} { return Formatter }
+func (standardFormat) TypeKey() interface{} { return FormatterType }
 func (sf standardFormat) Apply(logger Logger) error {
 	return applyFormatter(sf, logger)
 }
 
 func NewJSONFormat() Config             { return jsonFormat{} }
-func (jsonFormat) TypeKey() interface{} { return Formatter }
+func (jsonFormat) TypeKey() interface{} { return FormatterType }
 func (jf jsonFormat) Apply(logger Logger) error {
 	return applyFormatter(jf, logger)
 }

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"io"
+	"time"
 
 	"github.com/arr-ai/frozen"
 )
@@ -22,6 +23,23 @@ type Logger interface {
 	Infof(format string, args ...interface{})
 }
 
+// LogEntry describes an entry to log.
+type LogEntry struct {
+
+	// Time at which the log entry was created
+	Time time.Time
+
+	// Message passed to Debug, Info or Error
+	Message string
+
+	// Data set by the user.
+	Data frozen.Map
+
+	// True if the log is verbose (Debug), false otherwise (Info or Error)
+	Verbose bool
+}
+
+
 type copyable interface {
 	// Copy returns a logger whose data is copied from the caller.
 	Copy() Logger
@@ -33,8 +51,14 @@ type fieldSetter interface {
 }
 
 type Formattable interface {
-	// SetFormatter sets the formatter for the logger.￿
+	// SetFormatter sets the formatter for the logger.
+	// The formatter provided must also implement the Formatter interface.
 	SetFormatter(formatter Config) error
+}
+
+type Formatter interface {
+	// Format translates a log entry into a string representation
+	Format(*LogEntry) (string, error)
 }
 
 type SettableVerbosity interface {

--- a/log/logrus.go
+++ b/log/logrus.go
@@ -1,0 +1,77 @@
+package log
+
+import (
+	"github.com/arr-ai/frozen"
+	"github.com/sirupsen/logrus"
+)
+
+const dataFieldKey = "_data"
+
+// Log the given entry with the logrus logger.
+func logWithLogrus(logger *logrus.Logger, e *LogEntry) {
+	pkgLogEntryToLogrusEntry(logger, e).Log(verboseToLogrusLevel(e.Verbose), e.Message)
+}
+
+// Component to convert a logrus formatter into a pkg formatter.
+type logrusFormatterToPkgFormatter struct {
+	logger    *logrus.Logger
+	formatter logrus.Formatter
+}
+
+func (f logrusFormatterToPkgFormatter) Format(entry *LogEntry) (string, error) {
+	format, err := f.formatter.Format(pkgLogEntryToLogrusEntry(f.logger, entry))
+	if err != nil {
+		return "", err
+	}
+	return string(format), nil
+}
+
+// Component to convert a pkg formatter into a logrus formatter.
+type pkgFormatterToLogrusFormatter struct {
+	formatter Formatter
+}
+
+func (f pkgFormatterToLogrusFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	format, err := f.formatter.Format(logrusEntryToPkgLogEntry(entry))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(format), nil
+}
+
+// Convert the given pkg entry to a logrus entry.
+func pkgLogEntryToLogrusEntry(logger *logrus.Logger, entry *LogEntry) *logrus.Entry {
+	return &logrus.Entry{
+		Logger:  logger,
+		Data:    logrus.Fields{dataFieldKey: entry.Data},
+		Time:    entry.Time,
+		Level:   verboseToLogrusLevel(entry.Verbose),
+		Caller:  nil,
+		Message: entry.Message,
+		Buffer:  nil,
+		Context: nil,
+	}
+}
+
+// Convert the given pkg entry to a logrus entry.
+func logrusEntryToPkgLogEntry(entry *logrus.Entry) *LogEntry {
+	return &LogEntry{
+		Time:    entry.Time,
+		Message: entry.Message,
+		Data:    entry.Data[dataFieldKey].(frozen.Map),
+		Verbose: logrusLevelToVerbose(entry.Level),
+	}
+}
+
+// Convert the pkg concept of verbosity to a logrus level.
+func verboseToLogrusLevel(verbose bool) logrus.Level {
+	if verbose {
+		return logrus.DebugLevel
+	}
+	return logrus.InfoLevel
+}
+
+// Convert a logrus level to the pkg concept of verbosity.
+func logrusLevelToVerbose(level logrus.Level) bool {
+	return level == logrus.DebugLevel
+}

--- a/log/logrus_test.go
+++ b/log/logrus_test.go
@@ -1,0 +1,45 @@
+package log
+
+import (
+	"github.com/alecthomas/assert"
+	"github.com/arr-ai/frozen"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestLogrusPkgFormatters(t *testing.T) {
+	t.Parallel()
+
+	entry := &LogEntry{
+		Time:    time.Now(),
+		Message: "message",
+		Data:    frozen.NewMap(frozen.KV("cat", "dog")),
+		Verbose: true,
+	}
+
+	logger := logrus.New()
+	formatter := standardFormat{}
+	formatted, err := formatter.Format(entry)
+	require.NoError(t, err)
+	doubleWrappedFormatter := logrusFormatterToPkgFormatter{logger, pkgFormatterToLogrusFormatter{formatter}}
+	doubleWrappedFormatted, err := doubleWrappedFormatter.Format(entry)
+	require.NoError(t, err)
+	assert.Equal(t, formatted, doubleWrappedFormatted)
+}
+
+func TestLogrusPkgEntry(t *testing.T) {
+	t.Parallel()
+
+	entry := &LogEntry{
+		Time:    time.Now(),
+		Message: "message",
+		Data:    frozen.NewMap(frozen.KV("cat", "dog")),
+		Verbose: true,
+	}
+
+	logger := logrus.New()
+	roundTripEntry := logrusEntryToPkgLogEntry(pkgLogEntryToLogrusEntry(logger, entry))
+	assert.Equal(t, entry, roundTripEntry)
+}


### PR DESCRIPTION
Previously, the SetFormatter method method came with the requirement
that the formatter provided needed to be a logrus.Formatter component.
This exposed the internal components of the pkg log framework, making
the addition of concepts (such as hooks) also reliant on these internal
components.

This change adds two types: Entry and Formatter, where Formatter is
responsible for formatting a log Entry. Backwards compatibility is
maintained with the SetFormatter method (through type checking) to
support the setting of logrus.Formatter components. However, this
change is not completely backwards compatible because the exported
Formatter name, previously an integer type value, now represents the
formatting object. The previous Formatter name has been renamed to
FormatterType.