### PR TITLE
Add SetLogCaller to standard logger

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -230,8 +230,6 @@ fields. If another config of the same type is added, it will replace the old one
     f = log.WithConfigs(log.NewJSONFormat(), log.NewStandardFormat())
 ```
 
-Currently only the format can be configured.
-
 #### Logging Format
 
 Currently there is only one logger which is the `StandardLogger` which uses 
@@ -273,6 +271,43 @@ For example:
 ```
 
 In the current implementation, the fields are logged in a random order.
+
+#### Verbosity
+
+Setting the verbose mode of the logger will log debug entries:
+
+```go
+    ctx := context.Background()
+
+    // By default, the logger will not log debug entries
+    log.Info(ctx, "not logged")
+
+    // Make the logger log debug level entries
+    ctx = log.WithConfigs(log.SetVerboseMode(true)).Onto(ctx)
+    
+    // With verbose mode enabled, the logger will log debug entries
+    log.Info(ctx, "logged")
+```
+
+#### Log Caller
+
+Setting the logger to log the caller will include the a reference to the source from which the log
+was called:
+
+```go
+    ctx := context.Background()
+
+    // By default, the logger will not log the caller
+    // 2020-02-05T09:05:11.041651+11:00 INFO one
+    log.Info(ctx, "one")
+
+    // Make the logger log the caller
+    ctx = log.WithConfigs(log.SetLogCaller(true)).Onto(ctx)
+    
+    // With caller log enabled, the logger will log the caller
+    // 2020-02-05T09:05:11.041651+11:00 INFO two [/path/to/example.go:42]
+    log.Info(ctx, "two")
+```
 
 #### Custom configuration
 

--- a/log/README.md
+++ b/log/README.md
@@ -2,7 +2,9 @@
 
 ## Intro
 
-This library is a contextual logging library that makes use of context as part of the logging process. It is designed to make development easier by using the context variable to log instead of using a single global logger or passing a logger to every function.
+This library is a contextual logging library that makes use of context as part of the logging 
+process. It is designed to make development easier by using the context variable to log instead of 
+using a single global logger or passing a logger to every function.
 
 ## Getting Started
 
@@ -32,42 +34,68 @@ func main() {
 
 ### Do a lot of things in one operation
 
-The library focuses on doing multiple operations, whether it is adding fields or configuring the logger, in one chained operation. This makes setup and logging very simple, especially when they involve `Fields`.
+The library focuses on doing multiple operations, whether it is adding fields or configuring the 
+logger, in one chained operation. This makes setup and logging very simple, especially when they 
+involve `Fields`.
 
 ### Shallow Context Tree
 
-`Fields` are stored in the context tree when you use the `Onto` method. Doing many things in one operation allows you to produce a shallow context tree as you do not need to add `Fields` one-by-one. By finalizing the `Fields` operation using `Onto`, it ensures that it will only add all the provided `Fields` once. This is extremely beneficial when several fields must be logged, which is common in large and complex codebases.
+`Fields` are stored in the context tree when you use the `Onto` method. Doing many things in one 
+operation allows you to produce a shallow context tree as you do not need to add `Fields` 
+one-by-one. By finalizing the `Fields` operation using `Onto`, it ensures that it will only add all 
+the provided `Fields` once. This is extremely beneficial when several fields must be logged, which 
+is common in large and complex codebases.
 
 ### Greater control over `Fields` and `Logger`
 
-There are also many operations you can do on `Fields` as the library allows you to store fields in a variable for finer control. The `With` methods allow many different types of `Fields` to be entered and APIs like [`Chain`](https://godoc.org/github.com/anz-bank/pkg/log#Fields.Chain) and [`Suppress`](https://godoc.org/github.com/anz-bank/pkg/log#Suppress) make `Fields` a lot more customizable.
+There are also many operations you can do on `Fields` as the library allows you to store fields in a 
+variable for finer control. The `With` methods allow many different types of `Fields` to be entered 
+and APIs like [`Chain`](https://godoc.org/github.com/anz-bank/pkg/log#Fields.Chain) and 
+[`Suppress`](https://godoc.org/github.com/anz-bank/pkg/log#Suppress) make `Fields` a lot more 
+customizable.
 
 ### Immutability
 
 The library ensures that `Fields` are immutable and the real `Logger` is never exposed.
-Any access to the logger will return a copy. This is very beneficial in programs with concurrent processes.
+Any access to the logger will return a copy. This is very beneficial in programs with concurrent 
+processes.
 
 ### Customisable
 
-The library provides a lot of ways to customize your logger to meet your needs. You can create your own configuration or even an entirely different logger. The provided interfaces are small which makes it really easy to create your own configurations to the library.
+The library provides a lot of ways to customize your logger to meet your needs. You can create your 
+own configuration or even an entirely different logger. The provided interfaces are small which 
+makes it really easy to create your own configurations to the library.
 
 ### Compared to other solutions
 
-A very popular solution for logging in open source is the [logrus](https://github.com/sirupsen/logrus) library. While it is a great logging library, it does not provide a built-in `Fields` solution and a very high level of `Fields` manipulation. It also does not implement context properly as it requires you to create a custom format even after using their `WithContext` API. Finally, logrus has a large API, and while it provides a great amount of features, users can find it intimidating and confusing to use.
+A very popular solution for logging in open source is the [logrus](https://github.com/sirupsen/logrus) 
+library. While it is a great logging library, it does not provide a built-in `Fields` solution and a 
+very high level of `Fields` manipulation. It also does not implement context properly as it requires 
+you to create a custom format even after using their `WithContext` API. Finally, logrus has a large 
+API, and while it provides a great amount of features, users can find it intimidating and confusing 
+to use.
 
-Compared to logrus, the library provides a built-in solution in implementing context, the provided default formats ensure that context values that you need are logged. The library also provides a simple set of APIs that are easy to use. Everything you need that involves a logger, you can easily find it.
+Compared to logrus, the library provides a built-in solution in implementing context, the provided 
+default formats ensure that context values that you need are logged. The library also provides a 
+simple set of APIs that are easy to use. Everything you need that involves a logger, you can easily 
+find it.
 
 ## Main Features
 
 ### Fields
 
-Fields are key value data that are logged along with the log message. This library makes manipulating Fields easier and more flexible. With this library, everything is treated a Field, that includes Fields themselves, logger configuration, and even the logger itself. This makes it possible for you to create everything in one chained operation.
+Fields are key value data that are logged along with the log message. This library makes 
+manipulating Fields easier and more flexible. With this library, everything is treated a Field, 
+that includes Fields themselves, logger configuration, and even the logger itself. This makes it 
+possible for you to create everything in one chained operation.
 
 ```go
     f := log.With("key1", "value1")
 ```
 
-There is also the context fields where it will take values that correspond to the given context key. The context key can be any object but you have to provide the alias for the key. If the key does not have any value in the context, it will not be logged.
+There is also the context fields where it will take values that correspond to the given context key. 
+The context key can be any object but you have to provide the alias for the key. If the key does not 
+have any value in the context, it will not be logged.
 
 ```go
     f = log.WithCtxRef("alias", ctxKey{})
@@ -82,13 +110,19 @@ You can also add multiple Fields by chaining the operation.
        With("more key", 'q')
 ```
 
-One thing to remember, since fields are key value data, in the event of overlapping keys, values will be replaced based on the order of operation. In a chain operation, the later operations have higher precedence and will replace the keys. At this example, the value that corresponds to `another` is now `fields` instead of `key`.
+One thing to remember, since fields are key value data, in the event of overlapping keys, values 
+will be replaced based on the order of operation. In a chain operation, the later operations have 
+higher precedence and will replace the keys. At this example, the value that corresponds to 
+`another` is now `fields` instead of `key`.
 
 ```go
     f = f.With("another", "fields")
 ```
 
-As mentioned before, everything is treated as fields and that includes the logger and its configuration. Only one logger can be in fields and one of each type of configurations (e.g. only one rule for format etc). Because they are fields they will also follow the precedence rule, which means adding another logger or a configuration type will replace the older values.
+As mentioned before, everything is treated as fields and that includes the logger and its 
+configuration. Only one logger can be in fields and one of each type of configurations (e.g. only 
+one rule for format etc). Because they are fields they will also follow the precedence rule, which 
+means adding another logger or a configuration type will replace the older values.
 
 ```go
     f = f.
@@ -96,7 +130,8 @@ As mentioned before, everything is treated as fields and that includes the logge
           WithConfigs(log.NewJSONFormat())
 ```
 
-The fields then can be used to log directly (example in later section) or they can be saved in the context for later use by using the `Onto` API.
+The fields then can be used to log directly (example in later section) or they can be saved in the 
+context for later use by using the `Onto` API.
 
 ```go
     newCtx := f.Onto(ctx)
@@ -104,13 +139,16 @@ The fields then can be used to log directly (example in later section) or they c
 
 A couple more useful APIs to know.
 
-`Suppress` will ensure that the provided keys will not be logged. In this example, the key `another`, `more key`, and `alias` will not be logged. For context reference fields, you have to refer to them by their alias.
+`Suppress` will ensure that the provided keys will not be logged. In this example, the key 
+`another`, `more key`, and `alias` will not be logged. For context reference fields, you have to 
+refer to them by their alias.
 
 ```go
     f = f.Suppress("another", "more key", "alias")
 ```
 
-`Chain` provides a way of merging multiple fields. Just like before, precedence gets higher from left to right.
+`Chain` provides a way of merging multiple fields. Just like before, precedence gets higher from 
+left to right.
 
 ```go
     f1 := log.With("key1", "value1")
@@ -119,11 +157,18 @@ A couple more useful APIs to know.
     f = f.Chain(f1, f2, f3)
 ```
 
-A very important thing to note is that Fields are immutable which makes them thread-safe but it also means that you need to receive the returned value of fields operation as they do not mutate themselves.
+A very important thing to note is that Fields are immutable which makes them thread-safe but it also 
+means that you need to receive the returned value of fields operation as they do not mutate 
+themselves.
 
 ### Logging
 
-Logging can be accessed through the `Debug`, `Info`, and `Error` API.  Each of them also have their format function counterpart which are `Debugf`, `Infof`, and `Errorf`. `Debug` and `Debugf` is only logged when the logger is in the verbose mode while the others will always be logged. Each of the log functions require a context to be passed in. If the context contains fields, that fields will be logged along with the message given. If the context does not contain a logger a standard logger will be provided as the default.
+Logging can be accessed through the `Debug`, `Info`, and `Error` API.  Each of them also have their 
+format function counterpart which are `Debugf`, `Infof`, and `Errorf`. `Debug` and `Debugf` is only 
+logged when the logger is in the verbose mode while the others will always be logged. Each of the 
+log functions require a context to be passed in. If the context contains fields, that fields will be 
+logged along with the message given. If the context does not contain a logger a standard logger will 
+be provided as the default.
 
 ```go
     log.Debug(ctx, "this is debug")
@@ -132,14 +177,18 @@ Logging can be accessed through the `Debug`, `Info`, and `Error` API.  Each of t
     log.Infof(ctx, "%s with format", "this is info")
 ```
 
-For `Error` and `Errorf`, the error variable is required. The error message will be logged as a field with the key of `error_message`.
+For `Error` and `Errorf`, the error variable is required. The error message will be logged as a 
+field with the key of `error_message`.
 
 ```go
     log.Error(ctx, errors.New("error"), "this is error")
     log.Errorf(ctx, errors.New("error"), "%s with format", "this is error")
 ```
 
- If you would like to log certain fields without adding additional fields to the context, you can do so by using the same API on the additional fields. Additional fields are merged with the fields in context if the context contains fields and it also has higher precedence but they do not mutate the fields in context.
+If you would like to log certain fields without adding additional fields to the context, you can do 
+so by using the same API on the additional fields. Additional fields are merged with the fields in 
+context if the context contains fields and it also has higher precedence but they do not mutate the 
+fields in context.
 
 ```go
     log.With("additional", "fields").With("more", "fields").Debug(ctx, "debug")
@@ -149,7 +198,11 @@ For `Error` and `Errorf`, the error variable is required. The error message will
     log.Debug(ctx, "no additional fields")
 ```
 
-Should you require the logger object itself, you can do so by using the `From` API which will extract the logger in the context. If context does not have any logger, it will returns a new standard logger. The returned logger is copied for immutability. The logger returned by From have all the fields and configuration applied to it. The fields are also resolved, meaning any context reference will use any value in the context at the time of call.
+Should you require the logger object itself, you can do so by using the `From` API which will 
+extract the logger in the context. If context does not have any logger, it will returns a new 
+standard logger. The returned logger is copied for immutability. The logger returned by From have 
+all the fields and configuration applied to it. The fields are also resolved, meaning any context 
+reference will use any value in the context at the time of call.
 
 ```go
     logger := log.From(ctx)
@@ -160,7 +213,11 @@ Should you require the logger object itself, you can do so by using the `From` A
 
 ### Configuring logger
 
-Logger configurations are treated as fields. This can be done through the `WithConfigs` API. You can add multiple configurations in a single `WithConfigs` operation. The configurations can also be saved in a context along with other fields. Even if you replace the logger, the configurations stay and will always be applied to the logger. Only one type of each configuration type can exist in a fields. If another config of the same type is added, it will replace the old one.
+Logger configurations are treated as fields. This can be done through the `WithConfigs` API. You can 
+add multiple configurations in a single `WithConfigs` operation. The configurations can also be 
+saved in a context along with other fields. Even if you replace the logger, the configurations stay 
+and will always be applied to the logger. Only one type of each configuration type can exist in a 
+fields. If another config of the same type is added, it will replace the old one.
 
 ```go
     // This adds the JSON formatter to the logger.
@@ -177,7 +234,10 @@ Currently only the format can be configured.
 
 #### Logging Format
 
-Currently there is only one logger which is the `StandardLogger` which uses [logrus](https://github.com/sirupsen/logrus). The provided formatter implements logrus formatter system. There are two formatters, the JSON formatter and the Standard formatter (which is the default formatter when no configuration is added).
+Currently there is only one logger which is the `StandardLogger` which uses 
+[logrus](https://github.com/sirupsen/logrus). The provided formatter implements logrus formatter 
+system. There are two formatters, the JSON formatter and the Standard formatter (which is the 
+default formatter when no configuration is added).
 
 ##### JSON format
 
@@ -195,7 +255,8 @@ JSON formatter will log in the following format:
 }
 ```
 
-Fields will be logged as an object of the attribute `fields`. One thing to remember is that, for context reference, the key will use the provided alias.
+Fields will be logged as an object of the attribute `fields`. One thing to remember is that, for 
+context reference, the key will use the provided alias.
 
 ##### Standard format
 
@@ -215,7 +276,8 @@ In the current implementation, the fields are logged in a random order.
 
 #### Custom configuration
 
-It is possible to create your own configuration. You will have to create an object that implements the provided interface.
+It is possible to create your own configuration. You will have to create an object that implements 
+the provided interface.
 
 ```go
 type Config interface {
@@ -224,4 +286,6 @@ type Config interface {
 }
 ```
 
-`TypeKey()` returns the type of the configuration and `Apply()` will apply the configuration to the logger. For formatters, use the `FormatterType` type key provided by the library to ensure that it is recognized as a formatter.
+`TypeKey()` returns the type of the configuration and `Apply()` will apply the configuration to the 
+logger. For formatters, use the `FormatterType` type key provided by the library to ensure that it 
+is recognized as a formatter.

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -176,6 +176,16 @@ func TestWithConfigOutput(t *testing.T) {
 	logger.AssertExpectations(t)
 }
 
+func TestWithConfigLogCaller(t *testing.T) {
+	t.Parallel()
+
+	logger := newMockLogger()
+	setLogMockAssertion(logger, frozen.NewMap())
+	logger.On("SetLogCaller", true).Return(nil)
+	WithConfigs(SetLogCaller(false), SetLogCaller(true)).WithLogger(logger).From(context.Background())
+	logger.AssertExpectations(t)
+}
+
 func TestFrom(t *testing.T) {
 	for _, c := range getUnresolvedFieldsCases() {
 		c := c

--- a/log/config.go
+++ b/log/config.go
@@ -12,6 +12,7 @@ const (
 const (
 	verbosity internalTypeKey = iota
 	output
+	logCaller
 )
 
 type Config interface {
@@ -24,6 +25,7 @@ type jsonFormat struct{}
 
 type verboseMode struct{ on bool }
 type outputConfig struct{ writer io.Writer }
+type logCallerConfig struct{ on bool }
 
 func NewStandardFormat() Config             { return standardFormat{} }
 func (standardFormat) TypeKey() interface{} { return FormatterType }
@@ -55,6 +57,17 @@ func (outputConfig) TypeKey() interface{} { return output }
 
 func (o outputConfig) Apply(logger Logger) error {
 	return logger.(SettableOutput).SetOutput(o.writer)
+}
+
+// SetLogCaller sets whether or not a reference to the calling function is logged.
+func SetLogCaller(on bool) Config {
+	return logCallerConfig{on}
+}
+
+func (logCallerConfig) TypeKey() interface{} { return logCaller }
+
+func (c logCallerConfig) Apply(logger Logger) error {
+	return logger.(SettableLogCaller).SetLogCaller(c.on)
 }
 
 func applyFormatter(formatter Config, logger Logger) error {

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -35,10 +35,23 @@ type LogEntry struct {
 	// Data set by the user.
 	Data frozen.Map
 
+	// Source code reference of the calling function.
+	// Initialised if SetLogCaller is true.
+	Caller CodeReference
+
 	// True if the log is verbose (Debug), false otherwise (Info or Error)
 	Verbose bool
 }
 
+// CodeReference describes a reference to a point within a source code file.
+type CodeReference struct {
+
+	// Path of the file (within the local file system) where the source code is found
+	File string
+
+	// Line number (1-indexed) within the source code file
+	Line int
+}
 
 type copyable interface {
 	// Copy returns a logger whose data is copied from the caller.
@@ -69,4 +82,9 @@ type SettableVerbosity interface {
 type SettableOutput interface {
 	// SetOutput sets where the logger outputs to.
 	SetOutput(w io.Writer) error
+}
+
+type SettableLogCaller interface {
+	// SetLogCaller sets whether or not a reference to the calling function is logged.
+	SetLogCaller(on bool) error
 }

--- a/log/logrus.go
+++ b/log/logrus.go
@@ -6,6 +6,7 @@ import (
 )
 
 const dataFieldKey = "_data"
+const dataFieldCaller = "_caller"
 
 // Log the given entry with the logrus logger.
 func logWithLogrus(logger *logrus.Logger, e *LogEntry) {
@@ -43,7 +44,7 @@ func (f pkgFormatterToLogrusFormatter) Format(entry *logrus.Entry) ([]byte, erro
 func pkgLogEntryToLogrusEntry(logger *logrus.Logger, entry *LogEntry) *logrus.Entry {
 	return &logrus.Entry{
 		Logger:  logger,
-		Data:    logrus.Fields{dataFieldKey: entry.Data},
+		Data:    logrus.Fields{dataFieldKey: entry.Data, dataFieldCaller: entry.Caller},
 		Time:    entry.Time,
 		Level:   verboseToLogrusLevel(entry.Verbose),
 		Caller:  nil,
@@ -59,6 +60,7 @@ func logrusEntryToPkgLogEntry(entry *logrus.Entry) *LogEntry {
 		Time:    entry.Time,
 		Message: entry.Message,
 		Data:    entry.Data[dataFieldKey].(frozen.Map),
+		Caller:  entry.Data[dataFieldCaller].(CodeReference),
 		Verbose: logrusLevelToVerbose(entry.Level),
 	}
 }

--- a/log/logrus_test.go
+++ b/log/logrus_test.go
@@ -36,6 +36,7 @@ func TestLogrusPkgEntry(t *testing.T) {
 		Time:    time.Now(),
 		Message: "message",
 		Data:    frozen.NewMap(frozen.KV("cat", "dog")),
+		Caller:  CodeReference{"example.go", 123},
 		Verbose: true,
 	}
 

--- a/log/mockLogger.go
+++ b/log/mockLogger.go
@@ -59,3 +59,7 @@ func (m *mockLogger) SetVerbose(on bool) error {
 func (m *mockLogger) SetOutput(w io.Writer) error {
 	return m.Called(w).Error(0)
 }
+
+func (m *mockLogger) SetLogCaller(on bool) error {
+	return m.Called(on).Error(0)
+}

--- a/log/nullLogger.go
+++ b/log/nullLogger.go
@@ -63,6 +63,10 @@ func (n *nullLogger) SetOutput(w io.Writer) error {
 	return n.internal.SetOutput(w)
 }
 
+func (n *nullLogger) SetLogCaller(on bool) error {
+	return n.internal.SetLogCaller(on)
+}
+
 func setUpLogger() *standardLogger {
 	logger := NewStandardLogger().(*standardLogger)
 	logger.internal.SetOutput(&bytes.Buffer{})


### PR DESCRIPTION
This change adds the SetLogCaller method to the standard logger that
includes a reference to the calling function within the logged string.

To provide the ability to extend the behaviour of the logged caller
reference (to render the reference as a url link to the project in
which the calling function can be found), the SetCodeReferenceFormatter
method is also provided. When set, the formatter will render the
caller reference activated by SetLogCaller.