### PR TITLE
Add auto-tagging

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,18 @@
+name: bump version
+on:
+  push:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.17.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DEFAULT_BUMP: patch


### PR DESCRIPTION
Add auto-tagging of master branch with GitHub action. By default patch
version will be bumped. Add `#minor` or `#major` to commit message to bump
minor or major version.

For more details see: https://github.com/anothrNick/github-tag-action