### PR TITLE
Add mandatory linting

### DIFF
--- a/.github/workflows/go-darwin.yml
+++ b/.github/workflows/go-darwin.yml
@@ -22,7 +22,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Make
-        run: make
+      - name: Test
+        # lint-with-docker doesn't work on mac/win github actions. Just run test only.
+        run: make test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-windows.yml
+++ b/.github/workflows/go-windows.yml
@@ -22,7 +22,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Make
-        run: make
+      - name: Test
+        # lint-with-docker doesn't work on mac/win github actions. Just run test only.
+        run: make test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -25,7 +25,7 @@ type fieldsTest struct {
 	expected      frozen.Map
 }
 
-type testHook struct { }
+type testHook struct{}
 
 func (h *testHook) OnLogged(entry *LogEntry) error {
 	return nil
@@ -236,7 +236,7 @@ func TestOnto(t *testing.T) {
 			}
 			ctx := fields.Onto(context.Background())
 
-			logger = getLoggerFromContext(t, ctx)
+			logger = getLoggerFromContext(ctx, t)
 
 			logger.AssertExpectations(t)
 		})
@@ -327,15 +327,11 @@ func setLogMockAssertion(logger *mockLogger, fields frozen.Map) {
 func setPutFieldsAssertion(logger *mockLogger, fields frozen.Map) {
 	logger.On(
 		"PutFields",
-		mock.MatchedBy(
-			func(arg interface{}) bool {
-				return fields.Equal(arg)
-			},
-		),
+		mock.MatchedBy(fields.Equal),
 	).Return(logger)
 }
 
-func getLoggerFromContext(t *testing.T, ctx context.Context) *mockLogger {
+func getLoggerFromContext(ctx context.Context, t *testing.T) *mockLogger {
 	m, exists := ctx.Value(fieldsContextKey{}).(frozen.Map)
 	if !exists {
 		t.Fatal("Fields not set yet")

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -24,7 +24,7 @@ type Logger interface {
 }
 
 // LogEntry describes an entry to log.
-type LogEntry struct {
+type LogEntry struct { // nolint:golint // log.LogEntry stutters but is public API now.
 
 	// Time at which the log entry was created
 	Time time.Time

--- a/log/logrus_test.go
+++ b/log/logrus_test.go
@@ -1,12 +1,13 @@
 package log
 
 import (
+	"testing"
+	"time"
+
 	"github.com/alecthomas/assert"
 	"github.com/arr-ai/frozen"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestLogrusPkgFormatters(t *testing.T) {

--- a/log/standardLogger.go
+++ b/log/standardLogger.go
@@ -13,14 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type logrusLevelConfig interface {
-	getLogrusLevel() logrus.Level
-}
-
-type ioOutConfig interface {
-	getIoOut() io.Writer
-}
-
 type standardLogger struct {
 	internal  *logrus.Logger
 	fields    frozen.Map

--- a/log/standardLogger_test.go
+++ b/log/standardLogger_test.go
@@ -19,7 +19,7 @@ const (
 	simpleFormat = "%s"
 )
 
-var testError = errors.New("this is an error")
+var errTest = errors.New("this is an error")
 
 // to test fields output for all log
 var testField = generateMultipleFieldsCases()[0].Fields
@@ -94,46 +94,46 @@ func TestDebugf(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	testStandardLogOutput(t, logrus.InfoLevel, frozen.NewMap().With(errMsgKey, testError.Error()), func() {
-		NewStandardLogger().Error(testError, testMessage)
+	testStandardLogOutput(t, logrus.InfoLevel, frozen.NewMap().With(errMsgKey, errTest.Error()), func() {
+		NewStandardLogger().Error(errTest, testMessage)
 	})
 
-	testJSONLogOutput(t, logrus.InfoLevel, frozen.NewMap().With(errMsgKey, testError.Error()), func() {
+	testJSONLogOutput(t, logrus.InfoLevel, frozen.NewMap().With(errMsgKey, errTest.Error()), func() {
 		logger := getNewStandardLogger()
 		require.NoError(t, logger.SetFormatter(NewJSONFormat()))
-		logger.Error(testError, testMessage)
+		logger.Error(errTest, testMessage)
 	})
 
-	testStandardLogOutput(t, logrus.InfoLevel, testField.With(errMsgKey, testError.Error()), func() {
-		getStandardLoggerWithFields().Error(testError, testMessage)
+	testStandardLogOutput(t, logrus.InfoLevel, testField.With(errMsgKey, errTest.Error()), func() {
+		getStandardLoggerWithFields().Error(errTest, testMessage)
 	})
 
-	testJSONLogOutput(t, logrus.InfoLevel, testField.With(errMsgKey, testError.Error()), func() {
+	testJSONLogOutput(t, logrus.InfoLevel, testField.With(errMsgKey, errTest.Error()), func() {
 		logger := getStandardLoggerWithFields()
 		require.NoError(t, logger.SetFormatter(NewJSONFormat()))
-		logger.Error(testError, testMessage)
+		logger.Error(errTest, testMessage)
 	})
 }
 
 func TestErrorf(t *testing.T) {
-	testStandardLogOutput(t, logrus.InfoLevel, frozen.NewMap().With(errMsgKey, testError.Error()), func() {
-		NewStandardLogger().Errorf(testError, simpleFormat, testMessage)
+	testStandardLogOutput(t, logrus.InfoLevel, frozen.NewMap().With(errMsgKey, errTest.Error()), func() {
+		NewStandardLogger().Errorf(errTest, simpleFormat, testMessage)
 	})
 
-	testJSONLogOutput(t, logrus.InfoLevel, frozen.NewMap().With(errMsgKey, testError.Error()), func() {
+	testJSONLogOutput(t, logrus.InfoLevel, frozen.NewMap().With(errMsgKey, errTest.Error()), func() {
 		logger := getNewStandardLogger()
 		require.NoError(t, logger.SetFormatter(NewJSONFormat()))
-		logger.Errorf(testError, simpleFormat, testMessage)
+		logger.Errorf(errTest, simpleFormat, testMessage)
 	})
 
-	testStandardLogOutput(t, logrus.InfoLevel, testField.With(errMsgKey, testError.Error()), func() {
-		getStandardLoggerWithFields().Errorf(testError, simpleFormat, testMessage)
+	testStandardLogOutput(t, logrus.InfoLevel, testField.With(errMsgKey, errTest.Error()), func() {
+		getStandardLoggerWithFields().Errorf(errTest, simpleFormat, testMessage)
 	})
 
-	testJSONLogOutput(t, logrus.InfoLevel, testField.With(errMsgKey, testError.Error()), func() {
+	testJSONLogOutput(t, logrus.InfoLevel, testField.With(errMsgKey, errTest.Error()), func() {
 		logger := getStandardLoggerWithFields()
 		require.NoError(t, logger.SetFormatter(NewJSONFormat()))
-		logger.Errorf(testError, simpleFormat, testMessage)
+		logger.Errorf(errTest, simpleFormat, testMessage)
 	})
 }
 
@@ -288,14 +288,13 @@ func TestAddHooksInfoLevel(t *testing.T) {
 }
 
 func TestLogCaller(t *testing.T) {
-
 	// test standard logger
 	actualOutput := redirectOutput(t, func() {
 		logger := getNewStandardLogger()
 		require.NoError(t, logger.SetLogCaller(true))
 		logger.Debug(testMessage)
 	})
-	assert.Regexp(t, regexp.MustCompile(".*\\[.*standardLogger_test.go:\\d+]"), actualOutput)
+	assert.Regexp(t, regexp.MustCompile(`.*\[.*standardLogger_test.go:\d+]`), actualOutput)
 
 	// test json logger
 	out := make(map[string]interface{})
@@ -306,7 +305,7 @@ func TestLogCaller(t *testing.T) {
 		logger.Debug(testMessage)
 	})), &out))
 	assert.Equal(t, out["message"], testMessage)
-	assert.Regexp(t, regexp.MustCompile(".*standardLogger_test.go:\\d+"), out["caller"])
+	assert.Regexp(t, regexp.MustCompile(`.*standardLogger_test.go:\d+`), out["caller"])
 }
 
 func getNewStandardLogger() *standardLogger {


### PR DESCRIPTION
Add linting to Makefile `make lint` and to CI proxy. Fix up all linter
errors. No additional code changes other than prompted by linter were made.