### PR TITLE
Make null logger log nothing

### DIFF
--- a/log/nullLogger.go
+++ b/log/nullLogger.go
@@ -1,78 +1,49 @@
 package log
 
 import (
-	"bytes"
 	"io"
 
 	"github.com/arr-ai/frozen"
 )
 
-type nullLogger struct {
-	internal *standardLogger
-}
+type nullLogger struct{}
 
-// Create a null logger that outputs to a buffer, for benchmarking
+// Create a null logger that doesn't log
 func NewNullLogger() Logger {
-	return &nullLogger{internal: setUpLogger()}
+	return &nullLogger{}
 }
 
-func (n *nullLogger) Debug(args ...interface{}) {
-	n.internal.Debug(args...)
-}
-
-func (n *nullLogger) Debugf(format string, args ...interface{}) {
-	n.internal.Debugf(format, args...)
-}
-
-func (n *nullLogger) Error(errMsg error, args ...interface{}) {
-	n.internal.Error(errMsg, args...)
-}
-
-func (n *nullLogger) Errorf(errMsg error, format string, args ...interface{}) {
-	n.internal.Errorf(errMsg, format, args...)
-}
-
-func (n *nullLogger) Info(args ...interface{}) {
-	n.internal.Info(args...)
-}
-
-func (n *nullLogger) Infof(format string, args ...interface{}) {
-	n.internal.Infof(format, args...)
-}
+func (n *nullLogger) Debug(args ...interface{})                               {}
+func (n *nullLogger) Debugf(format string, args ...interface{})               {}
+func (n *nullLogger) Error(errMsg error, args ...interface{})                 {}
+func (n *nullLogger) Errorf(errMsg error, format string, args ...interface{}) {}
+func (n *nullLogger) Info(args ...interface{})                                {}
+func (n *nullLogger) Infof(format string, args ...interface{})                {}
 
 func (n *nullLogger) PutFields(fields frozen.Map) Logger {
-	n.internal.fields = fields
 	return n
 }
 
 func (n *nullLogger) Copy() Logger {
-	return &nullLogger{
-		setUpLogger().PutFields(n.internal.fields).(*standardLogger),
-	}
+	return &nullLogger{}
 }
 
 func (n *nullLogger) SetFormatter(formatter Config) error {
-	return n.internal.SetFormatter(formatter)
+	return nil
 }
 
 func (n *nullLogger) SetVerbose(on bool) error {
-	return n.internal.SetVerbose(on)
+	return nil
 }
 
 func (n *nullLogger) SetOutput(w io.Writer) error {
-	return n.internal.SetOutput(w)
+	return nil
 }
 
 func (n *nullLogger) AddHooks(hooks ...Hook) error {
-	return n.internal.AddHooks(hooks...)
+	return nil
 }
 
 func (n *nullLogger) SetLogCaller(on bool) error {
-	return n.internal.SetLogCaller(on)
-}
-
-func setUpLogger() *standardLogger {
-	logger := NewStandardLogger().(*standardLogger)
-	logger.internal.SetOutput(&bytes.Buffer{})
-	return logger
+	return nil
 }


### PR DESCRIPTION
Previously, the NewNullLogger used an internal logging component
that wrote logs to a byte buffer. This update removes the internal
logging component, making the null logger log nothing.