### PR TITLE
Include NewForwardingHook to connect one logger to another

### DIFF
--- a/log/api_test.go
+++ b/log/api_test.go
@@ -202,6 +202,23 @@ func TestWithConfigLogCaller(t *testing.T) {
 	logger.AssertExpectations(t)
 }
 
+func TestNewForwardingHook(t *testing.T) {
+	t.Parallel()
+
+	targetBuffer := bytes.Buffer{}
+	targetLogger := WithConfigs(SetOutput(&targetBuffer)).
+		WithLogger(NewStandardLogger()).
+		From(context.Background())
+	sourceBuffer := bytes.Buffer{}
+	sourceLogger := WithConfigs(SetOutput(&sourceBuffer), AddHooks(NewForwardingHook(targetLogger))).
+		WithLogger(NewStandardLogger()).
+		From(context.Background())
+
+	sourceLogger.Info("message")
+	assert.True(t, sourceBuffer.Len() > 0)
+	assert.Equal(t, sourceBuffer, targetBuffer)
+}
+
 func TestFrom(t *testing.T) {
 	for _, c := range getUnresolvedFieldsCases() {
 		c := c

--- a/log/config.go
+++ b/log/config.go
@@ -86,3 +86,17 @@ func (c logCallerConfig) Apply(logger Logger) error {
 func applyFormatter(formatter Config, logger Logger) error {
 	return logger.(Formattable).SetFormatter(formatter)
 }
+
+type forwardingHook struct {
+	logger Logger
+}
+
+func (h *forwardingHook) OnLogged(entry *LogEntry) error {
+	h.logger.(entryLogger).Log(entry)
+	return nil
+}
+
+// NewForwardingHook returns a Hook that forwards all entries to the given Logger.
+func NewForwardingHook(logger Logger) Hook {
+	return &forwardingHook{logger}
+}

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -68,6 +68,11 @@ type fieldSetter interface {
 	PutFields(fields frozen.Map) Logger
 }
 
+type entryLogger interface {
+	// Log the given log entry.
+	Log(entry *LogEntry)
+}
+
 type Formattable interface {
 	// SetFormatter sets the formatter for the logger.
 	// The formatter provided must also implement the Formatter interface.

--- a/log/mockLogger.go
+++ b/log/mockLogger.go
@@ -40,6 +40,10 @@ func (m *mockLogger) Infof(format string, args ...interface{}) {
 	m.Called(append([]interface{}{format}, args...)...)
 }
 
+func (m *mockLogger) Log(entry *LogEntry) {
+	m.Called(entry)
+}
+
 func (m *mockLogger) PutFields(fields frozen.Map) Logger {
 	return m.Called(fields).Get(0).(Logger)
 }

--- a/log/nullLogger.go
+++ b/log/nullLogger.go
@@ -19,6 +19,7 @@ func (n *nullLogger) Error(errMsg error, args ...interface{})                 {}
 func (n *nullLogger) Errorf(errMsg error, format string, args ...interface{}) {}
 func (n *nullLogger) Info(args ...interface{})                                {}
 func (n *nullLogger) Infof(format string, args ...interface{})                {}
+func (n *nullLogger) Log(entry *LogEntry)                                     {}
 
 func (n *nullLogger) PutFields(fields frozen.Map) Logger {
 	return n

--- a/log/standardLogger.go
+++ b/log/standardLogger.go
@@ -107,6 +107,10 @@ func (sl *standardLogger) Infof(format string, args ...interface{}) {
 	sl.logf(false, format, args...)
 }
 
+func (sl *standardLogger) Log(entry *LogEntry) {
+	logWithLogrus(sl.internal, entry)
+}
+
 func (sl *standardLogger) PutFields(fields frozen.Map) Logger {
 	sl.fields = fields
 	return sl


### PR DESCRIPTION
The AddHooks config allows log entries to be received outside the
logger, however, the Logger interface doesn't provide a means to
log the LogEntry objects received within the Hook.

The NewForwardingHook method provides a mechanism to forward log
entries directly to another Logger. This method is preferred over
the addition of a method to the Logger interface in an attempt to
keep the Logger interface clean.