### PR TITLE
health: Add HTTPServer.RegisterWith method

### DIFF
--- a/health/health_test.go
+++ b/health/health_test.go
@@ -245,7 +245,7 @@ func TestHTTPNotFound(t *testing.T) {
 }
 
 func TestHTTPMethodNotAllowed(t *testing.T) {
-	req := httptest.NewRequest("POST", "http://example.com/MISSING_PATH", nil)
+	req := httptest.NewRequest("POST", "http://example.com/version", nil)
 	w := httptest.NewRecorder()
 	s, err := NewHTTPServer()
 	require.NoError(t, err)
@@ -259,7 +259,7 @@ func TestHTTPMethodNotAllowed(t *testing.T) {
 	require.Equal(t, "405 method not allowed, use GET\n", string(body))
 }
 
-func TestRegisterWith(t *testing.T) {
+func TestGRPCRegisterWith(t *testing.T) {
 	grpcServer := grpc.NewServer()
 	hs, err := NewGRPCServer()
 	require.NoError(t, err)


### PR DESCRIPTION
Add the `RegisterWith` method to `HTTPServer` to register all three
health paths with a mux. The mux needs to implement the `health.Router`
interface which `http.ServeMux`does . `chi` also does, for example.
Unfortunately `gorilla/mux` does not (it has a return value).

Reimplement `ServeHTTP` in with `RegisterWith` on a `http.ServeMux` to
remove the code duplication that would have otherwise existed.

Adjust the `TestHTTPMethodNotAllowed` test as the order of checking
paths and methods have changed.

Also rename `TestRegisterWith` to `TestGRPCRegisterWith` since there is
now another `RegisterWith`.