### PR TITLE
health: Add DefaultServer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - dupl
     - errcheck
     - gochecknoinits
-    - goconst
     - gocritic
     - gocyclo
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean::  ## Remove generated files
 # -- Test --------------------------------------------------------------
 
 COVERFILE = coverage.out
-COVERAGE = 90.4
+COVERAGE = 91.0
 
 test:  ## Run tests and generate a coverage file
 	go test -coverprofile=$(COVERFILE) ./...

--- a/health/default.go
+++ b/health/default.go
@@ -1,0 +1,71 @@
+package health
+
+import (
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+var (
+	// DefaultServer is the Server instance on which the package-level functions
+	// operate. Most servers need only a single health server so this provides
+	// a convenient definition of it that is available everywhere.
+	DefaultServer *Server
+	defaultState  State
+
+	serverInit sync.Once
+)
+
+// RegisterWithGRPC registers the default server
+// health.DefaultServer.GRPC with the given grpc Server to make the
+// health service available at "anz.health.v1.Health". This
+// RegisterWithGRPC function returns an error when the Version
+// information is invalid.
+func RegisterWithGRPC(s *grpc.Server) error {
+	var err error
+	serverInit.Do(func() { err = newDefaultServer() })
+	if err != nil {
+		return err
+	}
+	DefaultServer.GRPC.RegisterWith(s)
+	return nil
+}
+
+// RegisterWithHTTP registers the default server
+// health.DefaultServer.HTTP with the given Router, e.g. a
+// http.ServeMux, to make the health service endpoints available at
+// /healthz, /readyz and /version. This RegisterWithHTTP function
+// returns an error when the Version information is invalid.
+func RegisterWithHTTP(r Router) error {
+	var err error
+	serverInit.Do(func() { err = newDefaultServer() })
+	if err != nil {
+		return err
+	}
+	DefaultServer.HTTP.RegisterWith(r)
+	return nil
+}
+
+// SetReady sets the ready status served by the DefaultServer. The value
+// can be changed as many times as is necessary over the lifetime of the
+// application. It is valid to call SetReady before the DefaultServer
+// has been registered, however a invalid version information will only
+// be detected when RegisterWithHTTP or RegisterWithGRPC is called.
+func SetReady(ready bool) {
+	defaultState.SetReady(ready)
+}
+
+func newDefaultServer() error {
+	v, err := newVersion()
+	if err != nil {
+		return err
+	}
+	defaultState.Version = v
+
+	DefaultServer = &Server{
+		GRPC:  &GRPCServer{State: &defaultState},
+		HTTP:  &HTTPServer{State: &defaultState},
+		State: &defaultState,
+	}
+	return nil
+}

--- a/health/default_test.go
+++ b/health/default_test.go
@@ -1,0 +1,84 @@
+package health
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestDefaultHTTPSetReady(t *testing.T) {
+	resetDefaults()
+	defer resetDefaults()
+
+	require.False(t, defaultState.Ready)
+	require.Nil(t, DefaultServer)
+
+	SetReady(true)
+	require.True(t, defaultState.Ready)
+	require.Nil(t, DefaultServer)
+
+	mux := http.NewServeMux()
+
+	err := RegisterWithHTTP(mux)
+	require.NoError(t, err)
+	require.True(t, defaultState.Ready)
+	require.NotNil(t, DefaultServer)
+	require.True(t, DefaultServer.State.Ready)
+}
+
+func TestDefaultGRPCSetReady(t *testing.T) {
+	resetDefaults()
+	defer resetDefaults()
+
+	require.False(t, defaultState.Ready)
+	require.Nil(t, DefaultServer)
+
+	SetReady(true)
+	require.True(t, defaultState.Ready)
+	require.Nil(t, DefaultServer)
+
+	grpcServer := grpc.NewServer()
+
+	err := RegisterWithGRPC(grpcServer)
+	require.NoError(t, err)
+	require.True(t, defaultState.Ready)
+	require.NotNil(t, DefaultServer)
+	require.True(t, DefaultServer.State.Ready)
+}
+
+func TestDefaultHTTPSetReadyErr(t *testing.T) {
+	resetDefaults()
+	defer resetDefaults()
+
+	RepoURL = "not a URL"
+	mux := http.NewServeMux()
+	err := RegisterWithHTTP(mux)
+	require.Error(t, err)
+	target := &url.Error{}
+	require.True(t, errors.As(err, &target))
+}
+
+func TestDefaultGRPCSetReadyErr(t *testing.T) {
+	resetDefaults()
+	defer resetDefaults()
+
+	RepoURL = "not a URL"
+	grpcServer := grpc.NewServer()
+	err := RegisterWithGRPC(grpcServer)
+	require.Error(t, err)
+	target := &url.Error{}
+	require.True(t, errors.As(err, &target))
+}
+
+func resetDefaults() {
+	DefaultServer = nil
+	defaultState = State{}
+	serverInit = sync.Once{}
+
+	resetGlobals()
+}

--- a/health/health_example_test.go
+++ b/health/health_example_test.go
@@ -15,6 +15,42 @@ import (
 )
 
 func Example() {
+	// normally set with go build linker option
+	health.RepoURL = "https://github.com/anz-bank/pkg"
+	health.CommitHash = "0123456789abcdef0123456789abcdef01234567"
+	health.Semver = "v1.2.3"
+
+	mux := http.NewServeMux()
+	// register other handlers with mux
+
+	err := health.RegisterWithHTTP(mux)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// [run expensive initialisation]
+
+	health.SetReady(true)
+
+	// In this example, we call the handler directly using httptest.
+	// Normally you would start a http server.
+	// http.ListenAndServe(":9090", mux)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, httptest.NewRequest("GET", "/readyz", nil))
+	mux.ServeHTTP(w, httptest.NewRequest("GET", "/version", nil))
+
+	fmt.Print(w.Body.String())
+	// output: 200 ok
+	// {
+	//   "repo_url": "https://github.com/anz-bank/pkg",
+	//   "commit_hash": "0123456789abcdef0123456789abcdef01234567",
+	//   "build_log_url": "undefined",
+	//   "container_tag": "undefined",
+	//   "semver": "v1.2.3"
+	// }
+}
+
+func ExampleNewServer() {
 	server, _ := health.NewServer()
 	go http.ListenAndServe(":8082", server.HTTP)
 


### PR DESCRIPTION
Add DefaultServer to health.pkg similarly to the DefaultServeMux in the
http package: for the simple case, the health package can now be used
without explicitly instantiating a health.Server:

	appServer := http.NewServeMux()
	// attach handlers to appServer

	health.RegisterWith(appServer)

	// expensive initialisation

	health.SetReady(tue)

Top-level functions RegisterWith, RegisterWithGRPC and SetReady operate
on the DefaultServer for convenience.

Update example and tests. Increase coverage by a little. Remove goconst
linter - it is fine to repeat `"not a URL"` in tests more than twice.