### PR TITLE
Fix githubMgr.Find: hit cache when find the specified file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/anz-bank/pkg
 go 1.13
 
 require (
+	bou.ke/monkey v1.0.2
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38
 	github.com/alecthomas/colour v0.1.0 // indirect
 	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 // indirect
-	github.com/anz-bank/sysl-examples v0.0.1 // indirect
 	github.com/arr-ai/frozen v0.11.1
 	github.com/golang/protobuf v1.4.0
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/prometheus v0.2.0 h1:9PUk0/8V0LGoPqVCrf8fQZJkFGBxudu8jOjQSMwoD6w=
 contrib.go.opencensus.io/exporter/prometheus v0.2.0/go.mod h1:TYmVAyE8Tn1lyPcltF5IYYfWp2KHu7lQGIZnj8iZMys=
@@ -14,10 +16,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/anz-bank/sysl-examples v0.0.1 h1:Qn+aF2847YGUdJzeJG7D4oa7cuFXt9X1O/JRTS+dG6o=
-github.com/anz-bank/sysl-examples v0.0.1/go.mod h1:AdokLChJxixvIBlAByw+kI13pAKawobfpcYCyPssvLQ=
-github.com/anz-bank/sysl-examples v0.0.2 h1:szNx6secul+G1tyQaWTMKXTD2YByJ/ln2V85O34IhZk=
-github.com/anz-bank/sysl-examples v0.0.2/go.mod h1:AdokLChJxixvIBlAByw+kI13pAKawobfpcYCyPssvLQ=
 github.com/arr-ai/frozen v0.11.1 h1:mX5fS6eeONZUNLFp/ZVEBaU+1RKUH8HgSUQflQm7YIA=
 github.com/arr-ai/frozen v0.11.1/go.mod h1:YEr4TubkrAoA3f9U1R4PcEVB5ocBUdiS3NKh03cbVts=
 github.com/arr-ai/hash v0.4.0 h1:VPIDl5nkhq8qntxmsNd00bdj+UVs2vRKFzzM7HZkR7Q=

--- a/mod/github.go
+++ b/mod/github.go
@@ -99,7 +99,10 @@ func (*githubMgr) Find(filename, ver string, m *Modules) *Module {
 	for _, mod := range *m {
 		if hasPathPrefix(mod.Name, filename) {
 			if mod.Version == ver {
-				return mod
+				relpath, err := filepath.Rel(mod.Name, filename)
+				if err == nil && fileExists(filepath.Join(mod.Dir, relpath), false) {
+					return mod
+				}
 			}
 		}
 	}

--- a/mod/github.go
+++ b/mod/github.go
@@ -3,6 +3,7 @@ package mod
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -54,6 +55,10 @@ func (d *githubMgr) Get(filename, ver string, m *Modules) (*Module, error) {
 		if _, ok := err.(*github.RateLimitError); ok {
 			return nil, errors.Wrap(err,
 				"\033[1;36mplease setup your GitHub access token\033[0m")
+		}
+		if err, ok := err.(*github.ErrorResponse); ok && err.Response.StatusCode == http.StatusNotFound {
+			return nil, errors.Wrap(err,
+				"\033[1;36mplease check whether your GitHub access token is set if it is a private repository\033[0m")
 		}
 		return nil, err
 	}

--- a/mod/github_test.go
+++ b/mod/github_test.go
@@ -1,8 +1,14 @@
 package mod
 
 import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
 	"testing"
 
+	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,14 +18,29 @@ func TestGitHubMgrInit(t *testing.T) {
 	err := githubmod.Init(&dir, nil)
 	assert.NoError(t, err)
 
+	var accessToken *string
+	rawToken := os.Getenv("GITHUB_ACCESS_TOKEN")
+	if rawToken != "" {
+		accessToken = &rawToken
+	}
+	err = githubmod.Init(&dir, accessToken)
+	assert.NoError(t, err)
+
 	err = githubmod.Init(nil, nil)
+	assert.Error(t, err)
+	err = githubmod.Init(nil, accessToken)
 	assert.Error(t, err)
 }
 
 func TestGitHubMgrGet(t *testing.T) {
 	githubmod := &githubMgr{}
 	dir := ".pkgcache"
-	err := githubmod.Init(&dir, nil)
+	var accessToken *string
+	rawToken := os.Getenv("GITHUB_ACCESS_TOKEN")
+	if rawToken != "" {
+		accessToken = &rawToken
+	}
+	err := githubmod.Init(&dir, accessToken)
 	assert.NoError(t, err)
 	testMods := Modules{}
 
@@ -42,25 +63,66 @@ func TestGitHubMgrGet(t *testing.T) {
 }
 
 func TestGitHubMgrFind(t *testing.T) {
-	githubmod := &githubMgr{}
+	cacheDir := ".pkgcache"
+	repo := "github.com/foo/bar"
+	filea := "filea"
+	fileb := "fileb"
+	tagRef := "v0.2.0"
+	masterRef := "v0.0.0-41f04d3bba15"
+	tagRepoDir := "github.com/foo/bar@v0.2.0"
+	masterRepoDir := "github.com/foo/bar@v0.0.0-41f04d3bba15"
+
+	githubmod := &githubMgr{cacheDir: cacheDir}
 	testMods := Modules{}
-	local := &Module{Name: "local", Version: "v0.0.1"}
-	mod1 := &Module{Name: "remote", Version: "v1.0.0-41f04d3bba15"}
-	mod2 := &Module{Name: "remote", Version: "v0.2.0"}
-	testMods.Add(local)
-	testMods.Add(mod1)
-	testMods.Add(mod2)
+	tagMod := &Module{
+		Name:    repo,
+		Version: tagRef,
+		Dir:     tagRepoDir,
+	}
+	masterMod := &Module{
+		Name:    repo,
+		Version: masterRef,
+		Dir:     masterRepoDir,
+	}
+	testMods.Add(tagMod)
+	testMods.Add(masterMod)
 
-	assert.Equal(t, local, githubmod.Find("local/filename", "v0.0.1", &testMods))
-	assert.Equal(t, local, githubmod.Find("local/filename2", "v0.0.1", &testMods))
-	assert.Equal(t, local, githubmod.Find(".//local/filename", "v0.0.1", &testMods))
-	assert.Equal(t, local, githubmod.Find("local", "v0.0.1", &testMods))
-	assert.Nil(t, githubmod.Find("local2/filename", "v0.0.1", &testMods))
+	monkey.Patch(FileExists, func(filename string, _ bool) bool {
+		files := []string{
+			filepath.Join(cacheDir, tagRepoDir, filea),
+			filepath.Join(cacheDir, tagRepoDir, fileb),
+			filepath.Join(cacheDir, masterRepoDir, filea),
+		}
+		for _, f := range files {
+			if filename == f {
+				return true
+			}
+		}
+		return false
+	})
 
-	assert.Nil(t, githubmod.Find("local/filename", MasterBranch, &testMods))
+	monkey.PatchInstanceMethod(reflect.TypeOf(githubmod), "CacheRef", func(_ *githubMgr, _ *githubRepoPath, ref string) (string, error) {
+		switch ref {
+		case tagRef:
+			return tagRef, nil
+		case MasterBranch:
+			return masterRef, nil
+		}
+		return "", fmt.Errorf("ref not found")
+	})
+	defer monkey.UnpatchAll()
 
-	assert.Equal(t, mod2, githubmod.Find("remote/filename", "v0.2.0", &testMods))
-	assert.Nil(t, githubmod.Find("remote/filename", "v1.0.0", &testMods))
+	assert.Equal(t, tagMod, githubmod.Find(path.Join(repo, filea), tagRef, &testMods))
+	assert.Equal(t, tagMod, githubmod.Find(path.Join(repo, fileb), tagRef, &testMods))
+	assert.Nil(t, githubmod.Find(repo, tagRef, &testMods))
+	assert.Nil(t, githubmod.Find(path.Join(repo, "wrong"), tagRef, &testMods))
+
+	assert.Equal(t, masterMod, githubmod.Find(path.Join(repo, filea), MasterBranch, &testMods))
+	assert.Equal(t, masterMod, githubmod.Find(path.Join(repo, filea), "", &testMods))
+	assert.Nil(t, githubmod.Find(repo, MasterBranch, &testMods))
+	assert.Nil(t, githubmod.Find(path.Join(repo, fileb), MasterBranch, &testMods))
+
+	assert.Nil(t, githubmod.Find("github.com/foo/wrongrepo/files", tagRef, &testMods))
 }
 
 func TestGetGitHubRepoPath(t *testing.T) {
@@ -87,4 +149,22 @@ func TestGetGitHubRepoPath(t *testing.T) {
 			assert.Equal(t, tt.path, p)
 		})
 	}
+}
+
+func TestCacheRef(t *testing.T) {
+	githubmod := &githubMgr{}
+	dir := ".pkgcache"
+	err := githubmod.Init(&dir, nil)
+	assert.NoError(t, err)
+	repoPath := &githubRepoPath{
+		owner: "anz-bank",
+		repo:  "pkg",
+	}
+	ref, err := githubmod.CacheRef(repoPath, "v0.0.7")
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.0.7", ref)
+
+	ref, err = githubmod.CacheRef(repoPath, MasterBranch)
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.0.0-", ref[:7])
 }

--- a/mod/github_test.go
+++ b/mod/github_test.go
@@ -18,29 +18,19 @@ func TestGitHubMgrInit(t *testing.T) {
 	err := githubmod.Init(&dir, nil)
 	assert.NoError(t, err)
 
-	var accessToken *string
-	rawToken := os.Getenv("GITHUB_ACCESS_TOKEN")
-	if rawToken != "" {
-		accessToken = &rawToken
-	}
-	err = githubmod.Init(&dir, accessToken)
+	err = githubmod.Init(&dir, accessTokenForTest())
 	assert.NoError(t, err)
 
 	err = githubmod.Init(nil, nil)
 	assert.Error(t, err)
-	err = githubmod.Init(nil, accessToken)
+	err = githubmod.Init(nil, accessTokenForTest())
 	assert.Error(t, err)
 }
 
 func TestGitHubMgrGet(t *testing.T) {
 	githubmod := &githubMgr{}
 	dir := ".pkgcache"
-	var accessToken *string
-	rawToken := os.Getenv("GITHUB_ACCESS_TOKEN")
-	if rawToken != "" {
-		accessToken = &rawToken
-	}
-	err := githubmod.Init(&dir, accessToken)
+	err := githubmod.Init(&dir, accessTokenForTest())
 	assert.NoError(t, err)
 	testMods := Modules{}
 
@@ -154,7 +144,7 @@ func TestGetGitHubRepoPath(t *testing.T) {
 func TestGetCacheRef(t *testing.T) {
 	githubmod := &githubMgr{}
 	dir := ".pkgcache"
-	err := githubmod.Init(&dir, nil)
+	err := githubmod.Init(&dir, accessTokenForTest())
 	assert.NoError(t, err)
 	repoPath := &githubRepoPath{
 		owner: "anz-bank",
@@ -167,4 +157,13 @@ func TestGetCacheRef(t *testing.T) {
 	ref, err = githubmod.GetCacheRef(repoPath, MasterBranch)
 	assert.NoError(t, err)
 	assert.Equal(t, "v0.0.0-", ref[:7])
+}
+
+func accessTokenForTest() *string {
+	var accessToken *string
+	rawToken := os.Getenv("GITHUB_ACCESS_TOKEN")
+	if rawToken != "" {
+		accessToken = &rawToken
+	}
+	return accessToken
 }

--- a/mod/github_test.go
+++ b/mod/github_test.go
@@ -101,7 +101,7 @@ func TestGitHubMgrFind(t *testing.T) {
 		return false
 	})
 
-	monkey.PatchInstanceMethod(reflect.TypeOf(githubmod), "CacheRef", func(_ *githubMgr, _ *githubRepoPath, ref string) (string, error) {
+	monkey.PatchInstanceMethod(reflect.TypeOf(githubmod), "GetCacheRef", func(_ *githubMgr, _ *githubRepoPath, ref string) (string, error) {
 		switch ref {
 		case tagRef:
 			return tagRef, nil
@@ -151,7 +151,7 @@ func TestGetGitHubRepoPath(t *testing.T) {
 	}
 }
 
-func TestCacheRef(t *testing.T) {
+func TestGetCacheRef(t *testing.T) {
 	githubmod := &githubMgr{}
 	dir := ".pkgcache"
 	err := githubmod.Init(&dir, nil)
@@ -160,11 +160,11 @@ func TestCacheRef(t *testing.T) {
 		owner: "anz-bank",
 		repo:  "pkg",
 	}
-	ref, err := githubmod.CacheRef(repoPath, "v0.0.7")
+	ref, err := githubmod.GetCacheRef(repoPath, "v0.0.7")
 	assert.NoError(t, err)
 	assert.Equal(t, "v0.0.7", ref)
 
-	ref, err = githubmod.CacheRef(repoPath, MasterBranch)
+	ref, err = githubmod.GetCacheRef(repoPath, MasterBranch)
 	assert.NoError(t, err)
 	assert.Equal(t, "v0.0.0-", ref[:7])
 }

--- a/mod/gomodules_test.go
+++ b/mod/gomodules_test.go
@@ -12,14 +12,12 @@ func TestModInit(t *testing.T) {
 	gomod := &goModules{}
 
 	// assumes the test folder (cwd) is not a go module folder
-	removeFile(t, fs, "go.sum")
-	removeFile(t, fs, "go.mod")
+	removeGomodFile(t, fs)
 
 	err := gomod.Init("test")
 	assert.NoError(t, err)
 
-	removeFile(t, fs, "go.sum")
-	removeFile(t, fs, "go.mod")
+	removeGomodFile(t, fs)
 }
 
 func TestModInitAlreadyExists(t *testing.T) {
@@ -27,8 +25,7 @@ func TestModInitAlreadyExists(t *testing.T) {
 	gomod := &goModules{}
 
 	// assumes the test folder (cwd) is not a go module folder
-	removeFile(t, fs, "go.sum")
-	removeFile(t, fs, "go.mod")
+	removeGomodFile(t, fs)
 
 	err := gomod.Init("test")
 	assert.NoError(t, err)
@@ -36,8 +33,7 @@ func TestModInitAlreadyExists(t *testing.T) {
 	err = gomod.Init("test")
 	assert.Error(t, err)
 
-	removeFile(t, fs, "go.sum")
-	removeFile(t, fs, "go.mod")
+	removeGomodFile(t, fs)
 }
 
 func TestGoModulesGet(t *testing.T) {

--- a/mod/module.go
+++ b/mod/module.go
@@ -59,7 +59,7 @@ func Config(m ModeType, gomodName, cacheDir, accessToken *string) error {
 		manager = gh
 	case GoModulesMode:
 		gm := &goModules{}
-		if !fileExists("go.mod", false) {
+		if !FileExists("go.mod", false) {
 			var modName string
 			if gomodName != nil {
 				modName = *gomodName
@@ -103,7 +103,7 @@ func hasPathPrefix(prefix, s string) bool {
 	return s == prefix
 }
 
-func fileExists(filename string, isDir bool) bool {
+func FileExists(filename string, isDir bool) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
 		return false

--- a/mod/module_test.go
+++ b/mod/module_test.go
@@ -33,7 +33,6 @@ func TestConfigGitHubMode(t *testing.T) {
 func TestConfigGoModulesMode(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	createGomodFile(t, fs)
-	defer removeGomodFile(t, fs)
 
 	gomodName := "mod"
 	err := Config(GoModulesMode, &gomodName, nil, nil)
@@ -62,7 +61,6 @@ func TestLen(t *testing.T) {
 func TestRetrieveGoModules(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	createGomodFile(t, fs)
-	defer removeGomodFile(t, fs)
 
 	filename := SyslDepsFile
 	mod, err := Retrieve(filename, "")
@@ -83,7 +81,6 @@ func TestRetrieveGoModules(t *testing.T) {
 func TestRetrieveWithWrongPath(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	createGomodFile(t, fs)
-	defer removeGomodFile(t, fs)
 
 	wrongpath := "wrong_file_path/deps.sysl"
 	mod, err := Retrieve(wrongpath, "")

--- a/mod/module_test.go
+++ b/mod/module_test.go
@@ -35,11 +35,8 @@ func TestConfigGoModulesMode(t *testing.T) {
 	createGomodFile(t, fs)
 	defer removeGomodFile(t, fs)
 
-	err := Config(GoModulesMode, nil, nil, nil)
-	assert.NoError(t, err)
-
 	gomodName := "mod"
-	err = Config(GoModulesMode, &gomodName, nil, nil)
+	err := Config(GoModulesMode, &gomodName, nil, nil)
 	assert.NoError(t, err)
 }
 

--- a/mod/module_test.go
+++ b/mod/module_test.go
@@ -31,7 +31,7 @@ func TestConfigGitHubMode(t *testing.T) {
 }
 
 func TestConfigGoModulesMode(t *testing.T) {
-	fs := afero.NewOsFs()
+	fs := afero.NewMemMapFs()
 	createGomodFile(t, fs)
 	defer removeGomodFile(t, fs)
 
@@ -63,7 +63,7 @@ func TestLen(t *testing.T) {
 }
 
 func TestRetrieveGoModules(t *testing.T) {
-	fs := afero.NewOsFs()
+	fs := afero.NewMemMapFs()
 	createGomodFile(t, fs)
 	defer removeGomodFile(t, fs)
 
@@ -84,7 +84,7 @@ func TestRetrieveGoModules(t *testing.T) {
 }
 
 func TestRetrieveWithWrongPath(t *testing.T) {
-	fs := afero.NewOsFs()
+	fs := afero.NewMemMapFs()
 	createGomodFile(t, fs)
 	defer removeGomodFile(t, fs)
 


### PR DESCRIPTION
Changes:
- only return mod when the specified file is found
- show instruction when the importing repo is private
- only re-download file when there are new commits pushed to ref `@ver`
- refine tests
