### PR TITLE
Add ReadyProvider to health pkg

### DIFF
--- a/health/default.go
+++ b/health/default.go
@@ -11,7 +11,7 @@ var (
 	// operate. Most servers need only a single health server so this provides
 	// a convenient definition of it that is available everywhere.
 	DefaultServer *Server
-	defaultState  State
+	defaultState  = State{ReadyProvider: new(readiness)}
 
 	serverInit sync.Once
 )

--- a/health/default_test.go
+++ b/health/default_test.go
@@ -15,40 +15,40 @@ func TestDefaultHTTPSetReady(t *testing.T) {
 	resetDefaults()
 	defer resetDefaults()
 
-	require.False(t, defaultState.Ready)
+	require.False(t, defaultState.IsReady())
 	require.Nil(t, DefaultServer)
 
 	SetReady(true)
-	require.True(t, defaultState.Ready)
+	require.True(t, defaultState.IsReady())
 	require.Nil(t, DefaultServer)
 
 	mux := http.NewServeMux()
 
 	err := RegisterWithHTTP(mux)
 	require.NoError(t, err)
-	require.True(t, defaultState.Ready)
+	require.True(t, defaultState.IsReady())
 	require.NotNil(t, DefaultServer)
-	require.True(t, DefaultServer.State.Ready)
+	require.True(t, DefaultServer.State.IsReady())
 }
 
 func TestDefaultGRPCSetReady(t *testing.T) {
 	resetDefaults()
 	defer resetDefaults()
 
-	require.False(t, defaultState.Ready)
+	require.False(t, defaultState.IsReady())
 	require.Nil(t, DefaultServer)
 
 	SetReady(true)
-	require.True(t, defaultState.Ready)
+	require.True(t, defaultState.IsReady())
 	require.Nil(t, DefaultServer)
 
 	grpcServer := grpc.NewServer()
 
 	err := RegisterWithGRPC(grpcServer)
 	require.NoError(t, err)
-	require.True(t, defaultState.Ready)
+	require.True(t, defaultState.IsReady())
 	require.NotNil(t, DefaultServer)
-	require.True(t, DefaultServer.State.Ready)
+	require.True(t, DefaultServer.State.IsReady())
 }
 
 func TestDefaultHTTPSetReadyErr(t *testing.T) {
@@ -77,7 +77,7 @@ func TestDefaultGRPCSetReadyErr(t *testing.T) {
 
 func resetDefaults() {
 	DefaultServer = nil
-	defaultState = State{}
+	defaultState = State{ReadyProvider: new(readiness)}
 	serverInit = sync.Once{}
 
 	resetGlobals()

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -24,11 +24,11 @@ func TestNewServer(t *testing.T) {
 
 func TestSetReady(t *testing.T) {
 	s, _ := NewServer()
-	require.False(t, s.State.Ready)
+	require.False(t, s.State.IsReady())
 	s.SetReady(true)
-	require.True(t, s.State.Ready)
+	require.True(t, s.State.IsReady())
 	s.SetReady(false)
-	require.False(t, s.State.Ready)
+	require.False(t, s.State.IsReady())
 }
 
 func TestAlive(t *testing.T) {

--- a/health/ochealth/register.go
+++ b/health/ochealth/register.go
@@ -123,7 +123,7 @@ func addReadyMetric(r *metric.Registry, ro *registerOptions, s *health.State) er
 		return err
 	}
 	return g.UpsertEntry(func() int64 {
-		if s.Ready {
+		if s.IsReady() {
 			return 1
 		}
 		return 0


### PR DESCRIPTION
Add ReadyProvider to health pkg such that Readiness can be determined
by users of the health package in a pull fashion, rather than pushing
it with `SetState(ready)`.