### PR TITLE
Add root to gomodules init param

### DIFF
--- a/mod/github.go
+++ b/mod/github.go
@@ -70,8 +70,7 @@ func (d *githubMgr) Get(filename, ver string, m *Modules) (*Module, error) {
 	fileContent, _, _, err := d.client.Repositories.GetContents(ctx, repoPath.owner, repoPath.repo, repoPath.path, refOps)
 	if err != nil {
 		if err, ok := err.(*github.RateLimitError); ok {
-			e := RateLimitError(*err)
-			return nil, &e
+			return nil, err
 		}
 		if err, ok := err.(*github.ErrorResponse); ok && err.Response.StatusCode == http.StatusNotFound {
 			return nil, &NotFoundError{Message: err.Error()}
@@ -225,7 +224,7 @@ func writeFile(filename string, content []byte) error {
 	return nil
 }
 
-const SHA_LENGTH = 12
+const SHALength = 12
 
 func (d *githubMgr) GetCacheRef(repoPath *githubRepoPath, ref string) (string, error) {
 	ctx := context.Background()
@@ -236,7 +235,7 @@ func (d *githubMgr) GetCacheRef(repoPath *githubRepoPath, ref string) (string, e
 
 	branch, _, err := d.client.Git.GetRef(ctx, repoPath.owner, repoPath.repo, "heads/"+ref)
 	if err == nil { // `ver` is a branch
-		return "v0.0.0-" + branch.GetObject().GetSHA()[:SHA_LENGTH], nil
+		return "v0.0.0-" + branch.GetObject().GetSHA()[:SHALength], nil
 	}
 	return "", err
 }

--- a/mod/github.go
+++ b/mod/github.go
@@ -20,23 +20,28 @@ type githubMgr struct {
 	cacheDir string
 }
 
-func (d *githubMgr) Init(cacheDir, accessToken *string) error {
-	if accessToken == nil {
+type GitHubOptions struct {
+	CacheDir    string
+	AccessToken string
+}
+
+func (d *githubMgr) Init(opt GitHubOptions) error {
+	if opt.AccessToken == "" {
 		d.client = github.NewClient(nil)
 	} else {
 		// Authenticated clients can make up to 5,000 requests per hour.
 		ts := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: *accessToken},
+			&oauth2.Token{AccessToken: opt.AccessToken},
 		)
 		tc := oauth2.NewClient(context.Background(), ts)
 
 		d.client = github.NewClient(tc)
 	}
 
-	if cacheDir == nil {
+	if opt.CacheDir == "" {
 		return errors.New("cache directory cannot be empty")
 	}
-	d.cacheDir = *cacheDir
+	d.cacheDir = opt.CacheDir
 	return nil
 }
 

--- a/mod/github_test.go
+++ b/mod/github_test.go
@@ -56,10 +56,8 @@ func TestGitHubMgrGet(t *testing.T) {
 func TestGitHubMgrFind(t *testing.T) {
 	cacheDir := ".pkgcache"
 	repo := "github.com/foo/bar"
-	filea := "filea"
-	fileb := "fileb"
-	tagRef := "v0.2.0"
-	masterRef := "v0.0.0-41f04d3bba15"
+	filea, fileb := "filea", "fileb"
+	tagRef, masterRef := "v0.2.0", "v0.0.0-41f04d3bba15"
 	tagRepoDir := "github.com/foo/bar@v0.2.0"
 	masterRepoDir := "github.com/foo/bar@v0.0.0-41f04d3bba15"
 
@@ -92,15 +90,16 @@ func TestGitHubMgrFind(t *testing.T) {
 		return false
 	})
 
-	monkey.PatchInstanceMethod(reflect.TypeOf(githubmod), "GetCacheRef", func(_ *githubMgr, _ *githubRepoPath, ref string) (string, error) {
-		switch ref {
-		case tagRef:
-			return tagRef, nil
-		case MasterBranch:
-			return masterRef, nil
-		}
-		return "", fmt.Errorf("ref not found")
-	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(githubmod), "GetCacheRef",
+		func(_ *githubMgr, _ *githubRepoPath, ref string) (string, error) {
+			switch ref {
+			case tagRef:
+				return tagRef, nil
+			case MasterBranch:
+				return masterRef, nil
+			}
+			return "", fmt.Errorf("ref not found")
+		})
 	defer monkey.UnpatchAll()
 
 	assert.Equal(t, tagMod, githubmod.Find(path.Join(repo, filea), tagRef, &testMods))

--- a/mod/github_test.go
+++ b/mod/github_test.go
@@ -15,22 +15,23 @@ import (
 func TestGitHubMgrInit(t *testing.T) {
 	githubmod := &githubMgr{}
 	dir := ".pkgcache"
-	err := githubmod.Init(&dir, nil)
+
+	err := githubmod.Init(GitHubOptions{CacheDir: dir})
 	assert.NoError(t, err)
 
-	err = githubmod.Init(&dir, accessTokenForTest())
+	err = githubmod.Init(GitHubOptions{CacheDir: dir, AccessToken: accessTokenForTest()})
 	assert.NoError(t, err)
 
-	err = githubmod.Init(nil, nil)
+	err = githubmod.Init(GitHubOptions{})
 	assert.Error(t, err)
-	err = githubmod.Init(nil, accessTokenForTest())
+	err = githubmod.Init(GitHubOptions{AccessToken: accessTokenForTest()})
 	assert.Error(t, err)
 }
 
 func TestGitHubMgrGet(t *testing.T) {
 	githubmod := &githubMgr{}
 	dir := ".pkgcache"
-	err := githubmod.Init(&dir, accessTokenForTest())
+	err := githubmod.Init(GitHubOptions{CacheDir: dir, AccessToken: accessTokenForTest()})
 	assert.NoError(t, err)
 	testMods := Modules{}
 
@@ -144,7 +145,7 @@ func TestGetGitHubRepoPath(t *testing.T) {
 func TestGetCacheRef(t *testing.T) {
 	githubmod := &githubMgr{}
 	dir := ".pkgcache"
-	err := githubmod.Init(&dir, accessTokenForTest())
+	err := githubmod.Init(GitHubOptions{CacheDir: dir, AccessToken: accessTokenForTest()})
 	assert.NoError(t, err)
 	repoPath := &githubRepoPath{
 		owner: "anz-bank",
@@ -159,11 +160,6 @@ func TestGetCacheRef(t *testing.T) {
 	assert.Equal(t, "v0.0.0-", ref[:7])
 }
 
-func accessTokenForTest() *string {
-	var accessToken *string
-	rawToken := os.Getenv("GITHUB_ACCESS_TOKEN")
-	if rawToken != "" {
-		accessToken = &rawToken
-	}
-	return accessToken
+func accessTokenForTest() string {
+	return os.Getenv("GITHUB_ACCESS_TOKEN")
 }

--- a/mod/gomodules.go
+++ b/mod/gomodules.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -24,10 +25,17 @@ type goModule struct {
 
 type goModules struct{}
 
-func (d *goModules) Init(modName string) error {
-	err := runGo(context.Background(), ioutil.Discard, "mod", "init", modName)
-	if err != nil {
-		return errors.New(fmt.Sprintf("go mod init failed: %s", err.Error()))
+type GoModulesOptions struct {
+	Root    string
+	ModName string
+}
+
+func (d *goModules) Init(opt GoModulesOptions) error {
+	if !FileExists(filepath.Join(opt.Root, "go.mod"), false) {
+		err := runGo(context.Background(), ioutil.Discard, "mod", "init", opt.ModName)
+		if err != nil {
+			return errors.New(fmt.Sprintf("go mod init failed: %s", err.Error()))
+		}
 	}
 
 	return nil

--- a/mod/gomodules_test.go
+++ b/mod/gomodules_test.go
@@ -14,7 +14,7 @@ func TestModInit(t *testing.T) {
 	// assumes the test folder (cwd) is not a go module folder
 	removeGomodFile(t, fs)
 
-	err := gomod.Init("test")
+	err := gomod.Init(GoModulesOptions{ModName: "test"})
 	assert.NoError(t, err)
 
 	removeGomodFile(t, fs)
@@ -27,13 +27,12 @@ func TestModInitAlreadyExists(t *testing.T) {
 	// assumes the test folder (cwd) is not a go module folder
 	removeGomodFile(t, fs)
 
-	err := gomod.Init("test")
+	err := gomod.Init(GoModulesOptions{ModName: "test"})
 	assert.NoError(t, err)
+	defer removeGomodFile(t, fs)
 
-	err = gomod.Init("test")
-	assert.Error(t, err)
-
-	removeGomodFile(t, fs)
+	err = gomod.Init(GoModulesOptions{ModName: "test"})
+	assert.NoError(t, err)
 }
 
 func TestGoModulesGet(t *testing.T) {

--- a/mod/module.go
+++ b/mod/module.go
@@ -48,25 +48,19 @@ func (m *Modules) Len() int {
 	return len(*m)
 }
 
-func Config(m ModeType, gomodName, cacheDir, accessToken *string) error {
+func Config(m ModeType, goModopt GoModulesOptions, githubOpt GitHubOptions) error {
 	mode = m
 	switch mode {
 	case GitHubMode:
 		gh := &githubMgr{}
-		if err := gh.Init(cacheDir, accessToken); err != nil {
+		if err := gh.Init(githubOpt); err != nil {
 			return err
 		}
 		manager = gh
 	case GoModulesMode:
 		gm := &goModules{}
-		if !FileExists("go.mod", false) {
-			var modName string
-			if gomodName != nil {
-				modName = *gomodName
-			}
-			if err := gm.Init(modName); err != nil {
-				return err
-			}
+		if err := gm.Init(goModopt); err != nil {
+			return err
 		}
 		manager = gm
 	default:

--- a/mod/module_test.go
+++ b/mod/module_test.go
@@ -1,7 +1,6 @@
 package mod
 
 import (
-	"os"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -16,17 +15,11 @@ const (
 )
 
 func TestConfigGitHubMode(t *testing.T) {
-	var accessToken *string
-	rawToken := os.Getenv("GITHUB_ACCESS_TOKEN")
-	if rawToken != "" {
-		accessToken = &rawToken
-	}
-
-	cacheDir := ".cache"
-	err := Config(GitHubMode, nil, &cacheDir, accessToken)
+	dir := ".pkgcache"
+	err := Config(GitHubMode, GoModulesOptions{}, GitHubOptions{CacheDir: dir, AccessToken: accessTokenForTest()})
 	assert.NoError(t, err)
 
-	err = Config(GitHubMode, nil, nil, accessToken)
+	err = Config(GitHubMode, GoModulesOptions{}, GitHubOptions{AccessToken: accessTokenForTest()})
 	assert.Error(t, err)
 }
 
@@ -34,13 +27,12 @@ func TestConfigGoModulesMode(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	createGomodFile(t, fs)
 
-	gomodName := "mod"
-	err := Config(GoModulesMode, &gomodName, nil, nil)
+	err := Config(GitHubMode, GoModulesOptions{ModName: "mod"}, GitHubOptions{CacheDir: ".pkgcache", AccessToken: accessTokenForTest()})
 	assert.NoError(t, err)
 }
 
 func TestConfigWrongMode(t *testing.T) {
-	err := Config("wrong", nil, nil, nil)
+	err := Config("wrong", GoModulesOptions{ModName: "mod"}, GitHubOptions{AccessToken: accessTokenForTest()})
 	assert.Error(t, err)
 }
 

--- a/mod/module_test.go
+++ b/mod/module_test.go
@@ -16,10 +16,12 @@ const (
 
 func TestConfigGitHubMode(t *testing.T) {
 	dir := ".pkgcache"
-	err := Config(GitHubMode, GoModulesOptions{}, GitHubOptions{CacheDir: dir, AccessToken: accessTokenForTest()})
+	err := Config(GitHubMode, GoModulesOptions{},
+		GitHubOptions{CacheDir: dir, AccessToken: accessTokenForTest()})
 	assert.NoError(t, err)
 
-	err = Config(GitHubMode, GoModulesOptions{}, GitHubOptions{AccessToken: accessTokenForTest()})
+	err = Config(GitHubMode, GoModulesOptions{},
+		GitHubOptions{AccessToken: accessTokenForTest()})
 	assert.Error(t, err)
 }
 
@@ -27,12 +29,18 @@ func TestConfigGoModulesMode(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	createGomodFile(t, fs)
 
-	err := Config(GitHubMode, GoModulesOptions{ModName: "mod"}, GitHubOptions{CacheDir: ".pkgcache", AccessToken: accessTokenForTest()})
+	err := Config(GitHubMode,
+		GoModulesOptions{ModName: "mod"},
+		GitHubOptions{CacheDir: ".pkgcache", AccessToken: accessTokenForTest()},
+	)
 	assert.NoError(t, err)
 }
 
 func TestConfigWrongMode(t *testing.T) {
-	err := Config("wrong", GoModulesOptions{ModName: "mod"}, GitHubOptions{AccessToken: accessTokenForTest()})
+	err := Config("wrong",
+		GoModulesOptions{ModName: "mod"},
+		GitHubOptions{AccessToken: accessTokenForTest()},
+	)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
- if the `go.mod` is already inited in under root path, it won't run `go mod init`