### PR TITLE
github: Fix version bump action label

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -3,7 +3,8 @@ on:
   push:
     branches: [ master ]
 jobs:
-  build:
+  version:
+    name: Bump version tag
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo


### PR DESCRIPTION
Update version bump action label from "build" (the GitHub action's job)
to something more meaningful and easier to identify in branch protection
settings.