### PR TITLE
health: Fix data race in health readiness access

### DIFF
--- a/health/default_test.go
+++ b/health/default_test.go
@@ -79,7 +79,8 @@ func TestSetReadyProvider(t *testing.T) {
 	resetDefaults()
 	defer resetDefaults()
 
-	r := readiness(true)
+	var r readiness
+	r.SetReady(true)
 	SetReadyProvider(&r)
 	require.Nil(t, DefaultServer)
 	mux := http.NewServeMux()


### PR DESCRIPTION
Make the readiness value a uint32 and read/write it with the `atomic`
package functions `LoadUint32` and `StoreUint32`, instead of unprotected
access to a boolean.

The health readiness value is read and written from different goroutines
mostly. This was explicitly done without locking as the readiness value
was a single bit and nothing that needed to be synchronised. That's
still bad. At least, it should be an atomic - no data should be
read/written concurrently without an atomic or a mutex or more.

Add a test case that fails the race detector if readiness is not
properly protected.