### PR TITLE
Includes FieldsFrom method in log

### DIFF
--- a/log/api.go
+++ b/log/api.go
@@ -171,3 +171,8 @@ func (f Fields) String(ctx context.Context) string {
 func (f Fields) MergedString(ctx context.Context) string {
 	return getFields(ctx).Chain(f).String(ctx)
 }
+
+// FieldsFrom retrieves the fields from the context.
+func FieldsFrom(ctx context.Context) Fields {
+	return getFields(ctx)
+}

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -336,6 +336,15 @@ func TestWithLogger(t *testing.T) {
 	logger.AssertExpectations(t)
 }
 
+func TestFieldsFrom(t *testing.T) {
+	t.Parallel()
+
+	fields := Fields{}.With("key", "value")
+	ctx := fields.Onto(context.Background())
+	retrieved := FieldsFrom(ctx)
+	assert.Equal(t, fields, retrieved)
+}
+
 func setLogMockAssertion(logger *mockLogger, fields frozen.Map) {
 	setMockCopyAssertion(logger)
 	setPutFieldsAssertion(logger, fields)


### PR DESCRIPTION
The FieldsFrom method is the reverse of Onto (that puts fields
into the context).